### PR TITLE
Vector syntax input accepted for Numpy-like ArrayVectors

### DIFF
--- a/pytissueoptics/tests/testsVectors.py
+++ b/pytissueoptics/tests/testsVectors.py
@@ -322,15 +322,68 @@ class TestVectorsBase(envtest.PyTissueTestCase):
 
 class TestNumpyVectors(envtest.PyTissueTestCase):
 
-    def testInitWithList(self):
-        v1 = NumpyVectors([[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]])
-        r = np.all(np.equal(v1.v, [[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]]))
+    def testInitNull(self):
+        v1 = NumpyVectors(N=2)
+        r = np.all(np.equal(v1.v, [[0, 0, 0], [0, 0, 0]]))
         self.assertTrue(r)
 
+    def testInitWithList(self):
+        with self.subTest("Double Nested List, Multiple Vectors, N=None"):
+            v1 = NumpyVectors([[1, -1, 1], [0, 0, 0]])
+            r = np.all(np.equal(v1.v, [[1, -1, 1], [0, 0, 0]]))
+            self.assertTrue(r)
+
+        with self.subTest("Double Nested List, Single Vector, N=None"):
+            v1 = NumpyVectors([[1, 1, 1]]*2)
+            r = np.all(np.equal(v1.v, [[1, 1, 1], [1, 1, 1]]))
+            self.assertTrue(r)
+
+        with self.subTest("Double Nested List, Single Vector, N=2"):
+            v1 = NumpyVectors([[1, 1, 1]], N=2)
+            r = np.all(np.equal(v1.v, [[1, 1, 1], [1, 1, 1]]))
+            self.assertTrue(r)
+
+        with self.subTest("Double Nested List, Single Vector, N=2"):
+            v1 = NumpyVectors([[1, 1, 1]], N=2)
+            r = np.all(np.equal(v1.v, [[1, 1, 1], [1, 1, 1]]))
+            self.assertTrue(r)
+
+        with self.subTest("Single List, Single Vector, N=2"):
+            v1 = NumpyVectors([1, 1, 1], N=2)
+            r = np.all(np.equal(v1.v, [[1, 1, 1], [1, 1, 1]]))
+            self.assertTrue(r)
+
     def testInitWithNumpyArray(self):
-        v1 = NumpyVectors(np.array([[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]]))
-        r = np.all(np.equal(v1.v, [[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]]))
-        self.assertTrue(r)
+        with self.subTest("Numpy Array, Multiple Vectors, N==None"):
+            v1 = NumpyVectors(np.array([[1, 1, 1], [0, 0, 0]]))
+            r = np.all(np.equal(v1.v, [[1, 1, 1], [0, 0, 0]]))
+            self.assertTrue(r)
+
+        with self.subTest("Numpy Array, Vectors, N==None"):
+            v1 = NumpyVectors(np.array([[1, 1, 1]]*2))
+            r = np.all(np.equal(v1.v, [[1, 1, 1], [1, 1, 1]]))
+            self.assertTrue(r)
+
+        with self.subTest("Numpy Array, Vectors, N=2"):
+            v1 = NumpyVectors(np.array([[1, 1, 1]]), N=2)
+            r = np.all(np.equal(v1.v, [[1, 1, 1], [1, 1, 1]]))
+            self.assertTrue(r)
+
+    def testInitWithVector(self):
+        with self.subTest("Single Vector, N==None"):
+            v1 = NumpyVectors(Vector(1, 1, 1))
+            r = np.all(np.equal(v1.v, [[1, 1, 1]]))
+            self.assertTrue(r)
+
+        with self.subTest("Multiple Vector, N==None"):
+            v1 = NumpyVectors([Vector(1, -1, 0)]*2)
+            r = np.all(np.equal(v1.v, [[1, -1, 0], [1, -1, 0]]))
+            self.assertTrue(r)
+
+        with self.subTest("Single Vector, N=2"):
+            v1 = NumpyVectors(Vector(1, -1, 0), N=2)
+            r = np.all(np.equal(v1.v, [[1, -1, 0], [1, -1, 0]]))
+            self.assertTrue(r)
 
     def testCheckInitTypeFloat64(self):
         v1 = NumpyVectors([[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]])

--- a/pytissueoptics/tests/testsVectors.py
+++ b/pytissueoptics/tests/testsVectors.py
@@ -822,15 +822,68 @@ class TestNumpyVectors(envtest.PyTissueTestCase):
 
 class TestCupyVectors(envtest.PyTissueTestCase):
 
-    def testInitWithList(self):
-        v1 = CupyVectors([[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]])
-        r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]])))
+    def testInitNull(self):
+        v1 = CupyVectors(N=2)
+        r = cp.all(cp.equal(v1.v, cp.asarray([[0, 0, 0], [0, 0, 0]])))
         self.assertTrue(r)
 
+    def testInitWithList(self):
+        with self.subTest("Double Nested List, Multiple Vectors, N=None"):
+            v1 = CupyVectors([[1, -1, 1], [0, 0, 0]])
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, -1, 1], [0, 0, 0]])))
+            self.assertTrue(r)
+
+        with self.subTest("Double Nested List, Single Vector, N=None"):
+            v1 = CupyVectors([[1, 1, 1]]*2)
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1], [1, 1, 1]])))
+            self.assertTrue(r)
+
+        with self.subTest("Double Nested List, Single Vector, N=2"):
+            v1 = CupyVectors([[1, 1, 1]], N=2)
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1], [1, 1, 1]])))
+            self.assertTrue(r)
+
+        with self.subTest("Double Nested List, Single Vector, N=2"):
+            v1 = CupyVectors([[1, 1, 1]], N=2)
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1], [1, 1, 1]])))
+            self.assertTrue(r)
+
+        with self.subTest("Single List, Single Vector, N=2"):
+            v1 = CupyVectors([1, 1, 0], N=2)
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 0], [1, 1, 0]])))
+            self.assertTrue(r)
+
     def testInitWithNumpyArray(self):
-        v1 = CupyVectors(cp.array([[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]]))
-        r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]])))
-        self.assertTrue(r)
+        with self.subTest("Numpy Array, Multiple Vectors, N==None"):
+            v1 = CupyVectors(np.array([[1, 1, 1], [0, 0, 0]]))
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1], [0, 0, 0]])))
+            self.assertTrue(r)
+
+        with self.subTest("Numpy Array, Vectors, N==None"):
+            v1 = CupyVectors(np.array([[1, 1, 1]]*2))
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1], [1, 1, 1]])))
+            self.assertTrue(r)
+
+        with self.subTest("Numpy Array, Vectors, N=2"):
+            v1 = CupyVectors(np.array([[1, 1, 1]]), N=2)
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1], [1, 1, 1]])))
+            self.assertTrue(r)
+
+    def testInitWithVector(self):
+        with self.subTest("Single Vector, N==None"):
+            v1 = CupyVectors(Vector(1, 1, 1))
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, 1, 1]])))
+            self.assertTrue(r)
+
+        with self.subTest("Single Vector, N=2"):
+            v1 = CupyVectors(Vector(1, -1, 0), N=2)
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, -1, 0], [1, -1, 0]])))
+            self.assertTrue(r)
+
+        with self.subTest("Multiple Vector, N==None"):
+            v1 = CupyVectors([Vector(1, -1, 0)]*2)
+            r = cp.all(cp.equal(v1.v, cp.asarray([[1, -1, 0], [1, -1, 0]])))
+            self.assertTrue(r)
 
     def testCheckInitTypeFloat64(self):
         v1 = CupyVectors([[1, 1, 1], [-0.04298243, 0.99337274, -0.10659786], [0, 1, 0], [-1, 0, 0]])

--- a/pytissueoptics/vectors.py
+++ b/pytissueoptics/vectors.py
@@ -241,13 +241,36 @@ class NumpyVectors:
     """
 
     def __init__(self, vectors=None, N=None):
-        if vectors is not None:
+        if vectors is not None and N is None:
             if type(vectors) == np.ndarray:
                 self.v = vectors.astype('float64')
 
+            elif type(vectors) == Vector:
+                self.v = np.asarray([[vectors.x, vectors.y, vectors.z]], dtype=np.float64)
+
+            elif type(vectors) == list and type(vectors[0]) == Vector:
+                x = [v.x for v in vectors]
+                y = [v.y for v in vectors]
+                z = [v.z for v in vectors]
+                self.v = np.stack((x, y, z), axis=-1)
+
             else:
                 self.v = np.asarray(vectors, dtype=np.float64)
-        elif N is not None:
+
+        elif vectors is not None and N is not None:
+            if type(vectors) == Vector:
+                self.v = np.asarray([[vectors.x, vectors.y, vectors.z]]*N, dtype=np.float64)
+
+            elif type(vectors) == list and type(vectors[0]) != list:
+                self.v = np.asarray([vectors] * N, dtype=np.float64)
+
+            elif type(vectors) == np.ndarray:
+                self.v = np.tile(vectors, (N, 1))
+
+            else:
+                self.v = np.asarray(vectors*N, dtype=np.float64)
+
+        elif vectors is None and N is not None:
             self.v = np.zeros((N, 3), dtype=np.float64)
             
         self._iteration = 0

--- a/pytissueoptics/vectors.py
+++ b/pytissueoptics/vectors.py
@@ -549,13 +549,39 @@ class CupyVectors:
     """
 
     def __init__(self, vectors=None, N=None):
-        if vectors is not None:
-            if type(vectors) == cp.ndarray:
+        if vectors is not None and N is None:
+            if type(vectors) == np.ndarray:
+                self.v = cp.asarray(vectors, dtype=cp.float64)
+
+            elif type(vectors) == cp.ndarray:
                 self.v = vectors.astype('float64')
+
+            elif type(vectors) == Vector:
+                self.v = cp.asarray([[vectors.x, vectors.y, vectors.z]], dtype=cp.float64)
+
+            elif type(vectors) == list and type(vectors[0]) == Vector:
+                x = cp.asarray([v.x for v in vectors])
+                y = cp.asarray([v.y for v in vectors])
+                z = cp.asarray([v.z for v in vectors])
+                self.v = cp.stack((x, y, z), axis=-1)
 
             else:
                 self.v = cp.asarray(vectors, dtype=cp.float64)
-        elif N is not None:
+
+        elif vectors is not None and N is not None:
+            if type(vectors) == Vector:
+                self.v = cp.asarray([[vectors.x, vectors.y, vectors.z]] * N, dtype=cp.float64)
+
+            elif type(vectors) == list and type(vectors[0]) != list:
+                self.v = cp.asarray([vectors] * N, dtype=cp.float64)
+
+            elif type(vectors) == np.ndarray:
+                self.v = cp.asarray(np.tile(vectors, (N, 1)))
+
+            else:
+                self.v = cp.asarray(vectors * N, dtype=cp.float64)
+
+        elif vectors is None and N is not None:
             self.v = cp.zeros((N, 3), dtype=cp.float64)
 
         self._iteration = 0


### PR DESCRIPTION
Now the syntax for `NativeVectors` initialization and `NumpyVectors` are alike, which allows the `Vector` class as input..
Here are all the possible methods of initializing an array:

```
v = NativeVectors(Vector(0,0,1))
v = NativeVectors([0,0,1])
v = NativeVectors([[0,0,1]])
v = NativeVectors(Vector(0,0,1), N=4)
v = NativeVectors([Vector(0,0,1)]*4)
v = NativeVectors([[0,0,1]]*4)
v = NativeVectors([0,0,1] N=4)
v = NativeVectors(N=4)
```
Works also with `np.ndarray` as input. 
