### PR TITLE
Implementation of a simple BoundingBox

### DIFF
--- a/pytissueoptics/scene/geometry/__init__.py
+++ b/pytissueoptics/scene/geometry/__init__.py
@@ -4,4 +4,3 @@ from .polygon import Polygon
 from .triangle import Triangle
 from .quad import Quad
 from .surfaceCollection import SurfaceCollection
-

--- a/pytissueoptics/scene/geometry/__init__.py
+++ b/pytissueoptics/scene/geometry/__init__.py
@@ -3,3 +3,4 @@ from .polygon import Polygon
 from .triangle import Triangle
 from .quad import Quad
 from .surfaceCollection import SurfaceCollection
+from .bbox import BoundingBox

--- a/pytissueoptics/scene/geometry/__init__.py
+++ b/pytissueoptics/scene/geometry/__init__.py
@@ -1,6 +1,7 @@
 from .vector import Vector
+from .bbox import BoundingBox
 from .polygon import Polygon
 from .triangle import Triangle
 from .quad import Quad
 from .surfaceCollection import SurfaceCollection
-from .bbox import BoundingBox
+

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -24,9 +24,7 @@ class BoundingBox:
             return False
 
     def _checkIfCoherent(self):
-        if self.xMax > self.xMin and self.yMax > self.yMin and self.zMax > self.zMin:
-            return True
-        else:
+        if not (self.xMax > self.xMin and self.yMax > self.yMin and self.zMax > self.zMin):
             raise ValueError("Maximum limit value cannot be lower than minimum limit value.")
 
     @classmethod

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -84,9 +84,3 @@ class BoundingBox:
     def change(self, axis="x", limit="max", value=0):
         self._xyzLimits[self._axisKeys.index(axis)][self._limitKeys.index(limit)] = value
         self._checkIfCoherent()
-
-    def changeToNew(self, axis="x", limit="max", value=0) -> BoundingBox:
-        newBbox = deepcopy(self)
-        newBbox.change(axis, limit, value)
-        newBbox._checkIfCoherent()
-        return newBbox

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -12,6 +12,7 @@ class BoundingBox:
         self._yLim = yLim
         self._zLim = zLim
         self._xyzLimits = [xLim, yLim, zLim]
+        self._checkIfCoherent()
 
     def __repr__(self) -> str:
         return str([self._xLim, self._yLim, self._zLim])
@@ -21,6 +22,12 @@ class BoundingBox:
             return True
         else:
             return False
+
+    def _checkIfCoherent(self):
+        if self.xMax > self.xMin and self.yMax > self.yMin and self.zMax > self.zMin:
+            return True
+        else:
+            raise ValueError("Maximum limit value cannot be lower than minimum limit value.")
 
     @classmethod
     def fromVertices(cls, vertices: List[Vector]) -> BoundingBox:

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -24,7 +24,7 @@ class BoundingBox:
             return False
 
     def _checkIfCoherent(self):
-        if not (self.xMax > self.xMin and self.yMax > self.yMin and self.zMax > self.zMin):
+        if not (self.xMax >= self.xMin and self.yMax >= self.yMin and self.zMax >= self.zMin):
             raise ValueError("Maximum limit value cannot be lower than minimum limit value.")
 
     @classmethod

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -22,6 +22,16 @@ class BoundingBox:
         else:
             return False
 
+    @classmethod
+    def fromVertices(cls, vertices: List[Vector]) -> BoundingBox:
+        x = [vertices[i].x for i in range(len(vertices))]
+        y = [vertices[i].y for i in range(len(vertices))]
+        z = [vertices[i].z for i in range(len(vertices))]
+        xLim = [min(x), max(x)]
+        yLim = [min(y), max(y)]
+        zLim = [min(z), max(z)]
+        return BoundingBox(xLim, yLim, zLim)
+
     @property
     def xMin(self) -> float:
         return self._xLim[0]

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 from typing import List
 from copy import deepcopy
-from pytissueoptics.scene import Vector
+from pytissueoptics.scene.geometry import Vector
 
 
 class BoundingBox:

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -1,6 +1,5 @@
-from __future__ import annotations
 from typing import List
-from copy import deepcopy
+
 from pytissueoptics.scene.geometry import Vector
 
 
@@ -17,7 +16,7 @@ class BoundingBox:
     def __repr__(self) -> str:
         return str([self._xLim, self._yLim, self._zLim])
 
-    def __eq__(self, other: BoundingBox) -> bool:
+    def __eq__(self, other: 'BoundingBox') -> bool:
         if self._xLim == other._xLim and self._yLim == other._yLim and self._zLim == other._zLim:
             return True
         else:
@@ -28,7 +27,7 @@ class BoundingBox:
             raise ValueError("Maximum limit value cannot be lower than minimum limit value.")
 
     @classmethod
-    def fromVertices(cls, vertices: List[Vector]) -> BoundingBox:
+    def fromVertices(cls, vertices: List[Vector]) -> 'BoundingBox':
         x = [vertices[i].x for i in range(len(vertices))]
         y = [vertices[i].y for i in range(len(vertices))]
         z = [vertices[i].z for i in range(len(vertices))]

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -84,9 +84,11 @@ class BoundingBox:
         return self._xyzLimits[index]
 
     def change(self, axis="x", limit="max", value=0):
-        self._xyzLimits[self._axisKeys.index(axis)][self._axisKeys.index(limit)] = value
+        self._xyzLimits[self._axisKeys.index(axis)][self._limitKeys.index(limit)] = value
+        self._checkIfCoherent()
 
     def changeToNew(self, axis="x", limit="max", value=0) -> BoundingBox:
         newBbox = deepcopy(self)
         newBbox.change(axis, limit, value)
+        newBbox._checkIfCoherent()
         return newBbox

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -80,7 +80,3 @@ class BoundingBox:
 
     def __getitem__(self, index: int) -> List[float]:
         return self._xyzLimits[index]
-
-    def change(self, axis="x", limit="max", value=0):
-        self._xyzLimits[self._axisKeys.index(axis)][self._limitKeys.index(limit)] = value
-        self._checkIfCoherent()

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+from typing import List
+from copy import deepcopy
+from pytissueoptics.scene import Vector
+
+
+class BoundingBox:
+    def __init__(self, xLim: List[float], yLim: List[float], zLim: List[float]):
+        self._axisKeys = ["x", "y", "z"]
+        self._limitKeys = ["min", "max"]
+        self._xLim = xLim
+        self._yLim = yLim
+        self._zLim = zLim
+        self._xyzLimits = [xLim, yLim, zLim]
+
+    def __repr__(self) -> str:
+        return str([self._xLim, self._yLim, self._zLim])
+
+    def __eq__(self, other: BoundingBox) -> bool:
+        if self._xLim == other._xLim and self._yLim == other._yLim and self._zLim == other._zLim:
+            return True
+        else:
+            return False
+
+    @property
+    def xMin(self) -> float:
+        return self._xLim[0]
+
+    @property
+    def xMax(self) -> float:
+        return self._xLim[1]
+
+    @property
+    def yMin(self) -> float:
+        return self._yLim[0]
+
+    @property
+    def yMax(self) -> float:
+        return self._yLim[1]
+
+    @property
+    def zMin(self) -> float:
+        return self._zLim[0]
+
+    @property
+    def zMax(self) -> float:
+        return self._zLim[1]
+
+    @property
+    def center(self) -> Vector:
+        return Vector(self.xMin + (self.xMax - self.xMin) / 2, self.yMin + (self.yMax - self.yMin) / 2,
+                      self.zMin + (self.zMax - self.zMin) / 2)
+
+    @property
+    def xLim(self) -> List[float]:
+        return self._xLim
+
+    @property
+    def yLim(self) -> List[float]:
+        return self._yLim
+
+    @property
+    def zLim(self) -> List[float]:
+        return self._zLim
+
+    def __getitem__(self, index: int) -> List[float]:
+        return self._xyzLimits[index]
+
+    def change(self, axis="x", limit="max", value=0):
+        self._xyzLimits[self._axisKeys.index(axis)][self._axisKeys.index(limit)] = value
+
+    def changeToNew(self, axis="x", limit="max", value=0) -> BoundingBox:
+        newBbox = deepcopy(self)
+        newBbox.change(axis, limit, value)
+        return newBbox

--- a/pytissueoptics/scene/geometry/polygon.py
+++ b/pytissueoptics/scene/geometry/polygon.py
@@ -19,6 +19,7 @@ class Polygon:
         self._normal = normal
         self._insideMaterial = insideMaterial
         self._outsideMaterial = outsideMaterial
+        self._bbox = self._getBoundingBox()
         if self._normal is None:
             self.resetNormal()
 
@@ -40,6 +41,9 @@ class Polygon:
 
     @property
     def bbox(self) -> BoundingBox:
+        return self._bbox
+
+    def _getBoundingBox(self) -> BoundingBox:
         return BoundingBox.fromVertices(self._vertices)
 
     def setOutsideMaterial(self, material: Material):

--- a/pytissueoptics/scene/geometry/polygon.py
+++ b/pytissueoptics/scene/geometry/polygon.py
@@ -19,7 +19,8 @@ class Polygon:
         self._normal = normal
         self._insideMaterial = insideMaterial
         self._outsideMaterial = outsideMaterial
-        self._bbox = self._getBoundingBox()
+        self._bbox = None
+        self.resetBoundingBox()
         if self._normal is None:
             self.resetNormal()
 
@@ -43,8 +44,8 @@ class Polygon:
     def bbox(self) -> BoundingBox:
         return self._bbox
 
-    def _getBoundingBox(self) -> BoundingBox:
-        return BoundingBox.fromVertices(self._vertices)
+    def resetBoundingBox(self) -> BoundingBox:
+        self._bbox = BoundingBox.fromVertices(self._vertices)
 
     def setOutsideMaterial(self, material: Material):
         self._outsideMaterial = material

--- a/pytissueoptics/scene/geometry/polygon.py
+++ b/pytissueoptics/scene/geometry/polygon.py
@@ -2,6 +2,7 @@ from typing import List
 
 from pytissueoptics.scene.geometry import Vector
 from pytissueoptics.scene.materials import Material
+from pytissueoptics.scene.geometry import BoundingBox
 
 
 class Polygon:
@@ -36,6 +37,10 @@ class Polygon:
     @property
     def outsideMaterial(self):
         return self._outsideMaterial
+
+    @property
+    def bbox(self) -> BoundingBox:
+        return BoundingBox.fromVertices(self._vertices)
 
     def setOutsideMaterial(self, material: Material):
         self._outsideMaterial = material

--- a/pytissueoptics/scene/geometry/polygon.py
+++ b/pytissueoptics/scene/geometry/polygon.py
@@ -44,7 +44,7 @@ class Polygon:
     def bbox(self) -> BoundingBox:
         return self._bbox
 
-    def resetBoundingBox(self) -> BoundingBox:
+    def resetBoundingBox(self):
         self._bbox = BoundingBox.fromVertices(self._vertices)
 
     def setOutsideMaterial(self, material: Material):

--- a/pytissueoptics/scene/geometry/polygon.py
+++ b/pytissueoptics/scene/geometry/polygon.py
@@ -19,10 +19,11 @@ class Polygon:
         self._normal = normal
         self._insideMaterial = insideMaterial
         self._outsideMaterial = outsideMaterial
-        self._bbox = None
-        self.resetBoundingBox()
         if self._normal is None:
             self.resetNormal()
+
+        self._bbox = None
+        self.resetBoundingBox()
 
     @property
     def normal(self):

--- a/pytissueoptics/scene/geometry/surfaceCollection.py
+++ b/pytissueoptics/scene/geometry/surfaceCollection.py
@@ -46,6 +46,10 @@ class SurfaceCollection:
         for polygon in self.getPolygons():
             polygon.resetNormal()
 
+    def resetBoundingBoxes(self):
+        for polygon in self.getPolygons():
+            polygon.resetBoundingBox()
+
     def extend(self, other: 'SurfaceCollection'):
         assert not any(self._contains(surface) for surface in other.surfaceNames)
         self._surfaces.update(other._surfaces)

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -16,6 +16,8 @@ class Solid:
         self._material = material
         self._primitive = primitive
         self._position = Vector(0, 0, 0)
+        self._bbox = None
+        self._resetBoundingBox()
 
         if not self._surfaces:
             self._computeMesh()
@@ -41,7 +43,11 @@ class Solid:
 
     @property
     def bbox(self) -> BoundingBox:
-        return BoundingBox.fromVertices(self._vertices)
+        return self._bbox
+
+    def _resetBoundingBox(self):
+        self._bbox = BoundingBox.fromVertices(self._vertices)
+        self._surfaces.resetBoundingBoxes()
 
     def translateTo(self, position):
         if position == self._position:
@@ -53,6 +59,7 @@ class Solid:
         self._position.add(translationVector)
         for v in self._vertices:
             v.add(translationVector)
+        self._resetBoundingBox()
 
     def rotate(self, xTheta=0, yTheta=0, zTheta=0):
         """
@@ -71,6 +78,7 @@ class Solid:
             vertex.update(*rotatedVertexArray)
 
         self._surfaces.resetNormals()
+        self._resetBoundingBox()
 
     def getMaterial(self, surfaceName: str = None) -> Material:
         if surfaceName:

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -17,13 +17,13 @@ class Solid:
         self._primitive = primitive
         self._position = Vector(0, 0, 0)
         self._bbox = None
-        self._resetBoundingBox()
 
         if not self._surfaces:
             self._computeMesh()
 
         self.translateTo(position)
         self._setInsideMaterial()
+        self._resetBoundingBox()
 
     @property
     def position(self) -> Vector:

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -2,7 +2,7 @@ from typing import List
 
 import numpy as np
 
-from pytissueoptics.scene.geometry import Vector, utils, Polygon
+from pytissueoptics.scene.geometry import Vector, utils, Polygon, BoundingBox
 from pytissueoptics.scene.geometry import primitives
 from pytissueoptics.scene.materials import Material
 from pytissueoptics.scene.geometry import SurfaceCollection
@@ -38,6 +38,10 @@ class Solid:
     @property
     def primitive(self) -> str:
         return self._primitive
+
+    @property
+    def bbox(self) -> BoundingBox:
+        return BoundingBox.fromVertices(self._vertices)
 
     def translateTo(self, position):
         if position == self._position:

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -1,0 +1,18 @@
+import unittest
+
+from pytissueoptics.scene.geometry import BoundingBox
+
+
+class TestBoundingBox(unittest.TestCase):
+    def testWhenCreatedEmpty_shouldRaiseException(self):
+        with self.assertRaises(Exception):
+            bbox = BoundingBox()
+
+    def testGivenLimits_whenAskingLimits_shouldReturnCorrectLimits(self):
+        xLim = [0, 1]
+        yLim = [-1, 0]
+        zLim = [0.5, -0.5]
+        bbox = BoundingBox(xLim, yLim, zLim)
+        self.assertEqual(bbox.xLim, xLim)
+        self.assertEqual(bbox.yLim, yLim)
+        self.assertEqual(bbox.zLim, zLim)

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -46,16 +46,6 @@ class TestBoundingBox(unittest.TestCase):
         self.assertEqual(bbox.yLim, [-1, 1])
         self.assertEqual(bbox.zLim, [0, 3.001])
 
-    def testGivenLimits_whenChangeLimits_shouldReturnNewLimits(self):
-        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
-        bbox.change("x", "max", 3)
-        self.assertEqual(bbox.xMax, 3)
-
-    def testGivenLimits_whenChangeToWrongLimits_shouldRaiseValueError(self):
-        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
-        with self.assertRaises(ValueError):
-            bbox.change("x", "max", -1)
-
     def testGiven2SimilarBBox_whenEquals_shouldReturnTrue(self):
         bbox1 = BoundingBox(self.xLim, self.yLim, self.zLim)
         bbox2 = BoundingBox(self.xLim, self.yLim, self.zLim)

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -19,33 +19,6 @@ class TestBoundingBox(unittest.TestCase):
         with self.assertRaises(ValueError):
             _ = BoundingBox(self.xLim, self.yLim, self.zLim)
 
-    def testGivenLimits_whenAskingLimits_shouldReturnCorrectLimits(self):
-        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
-
-        self.assertEqual(bbox.xLim, self.xLim)
-        self.assertEqual(bbox.yLim, self.yLim)
-        self.assertEqual(bbox.zLim, self.zLim)
-
-    def testGivenLimits_whenAskingMinMax_shouldReturnMinMax(self):
-        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
-
-        self.assertEqual(bbox.xMin, self.xLim[0])
-        self.assertEqual(bbox.xMax, self.xLim[1])
-        self.assertEqual(bbox.yMin, self.yLim[0])
-        self.assertEqual(bbox.yMax, self.yLim[1])
-        self.assertEqual(bbox.zMin, self.zLim[0])
-        self.assertEqual(bbox.zMax, self.zLim[1])
-
-    def testGivenNewBBoxFromVertices_whenAskingLimits_shouldReturnCorrectLimits(self):
-        v1 = Vector(0, 1, 0)
-        v2 = Vector(-1, 1, 2)
-        v3 = Vector(-0.1, -1, 3.001)
-        bbox = BoundingBox.fromVertices([v1, v2, v3])
-
-        self.assertEqual(bbox.xLim, [-1, 0])
-        self.assertEqual(bbox.yLim, [-1, 1])
-        self.assertEqual(bbox.zLim, [0, 3.001])
-
     def testGiven2SimilarBBox_whenEquals_shouldReturnTrue(self):
         bbox1 = BoundingBox(self.xLim, self.yLim, self.zLim)
         bbox2 = BoundingBox(self.xLim, self.yLim, self.zLim)

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -38,3 +38,4 @@ class TestBoundingBox(unittest.TestCase):
         self.assertEqual(bbox.xLim, [-1, 0])
         self.assertEqual(bbox.yLim, [-1, 1])
         self.assertEqual(bbox.zLim, [0, 3.001])
+    

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -1,12 +1,12 @@
 import unittest
 
-from pytissueoptics.scene.geometry import BoundingBox
+from pytissueoptics.scene.geometry import BoundingBox, Vector
 
 
 class TestBoundingBox(unittest.TestCase):
     def testWhenCreatedEmpty_shouldRaiseException(self):
         with self.assertRaises(Exception):
-            bbox = BoundingBox()
+            _ = BoundingBox()
 
     def testGivenLimits_whenAskingLimits_shouldReturnCorrectLimits(self):
         xLim = [0, 1]
@@ -16,3 +16,33 @@ class TestBoundingBox(unittest.TestCase):
         self.assertEqual(bbox.xLim, xLim)
         self.assertEqual(bbox.yLim, yLim)
         self.assertEqual(bbox.zLim, zLim)
+
+    def testGivenLimits_whenAskingMinMax_shouldReturnMinMax(self):
+        xLim = [0, 1]
+        yLim = [-1, 0]
+        zLim = [-0.5, 0.5]
+        bbox = BoundingBox(xLim, yLim, zLim)
+        self.assertEqual(bbox.xMin, xLim[0])
+        self.assertEqual(bbox.xMax, xLim[1])
+        self.assertEqual(bbox.yMin, yLim[0])
+        self.assertEqual(bbox.yMax, yLim[1])
+        self.assertEqual(bbox.zMin, zLim[0])
+        self.assertEqual(bbox.zMax, zLim[1])
+
+    def testGivenVertices_whenAskingLimits_shouldReturnCorrectLimits(self):
+        v1 = Vector(0, 1, 0)
+        v2 = Vector(-1, 1, 2)
+        v3 = Vector(-0.1, -1, 3.001)
+        bbox = BoundingBox.fromVertices([v1, v2, v3])
+        self.assertEqual(bbox.xLim, [-1, 0])
+        self.assertEqual(bbox.yLim, [-1, 1])
+        self.assertEqual(bbox.zLim, [0, 3.001])
+
+    def testGivenWrongLimits_whenInit_shouldReturnMinMax(self):
+        xLim = [0, 1]
+        yLim = [-1, 0]
+        zLim = [0.5, -0.5]
+        with self.assertRaises(ValueError):
+            _ = BoundingBox(xLim, yLim, zLim)
+
+    

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -10,18 +10,25 @@ class TestBoundingBox(unittest.TestCase):
         self.yLim = [-1, 0]
         self.zLim = [-0.5, 0.5]
     
-    def testWhenCreatedEmpty_shouldRaiseException(self):
+    def testGivenNoLimits_shouldRaiseException(self):
         with self.assertRaises(Exception):
             _ = BoundingBox()
 
+    def testGivenWrongLimits_shouldRaiseValueError(self):
+        self.zLim = [0.5, -0.5]
+        with self.assertRaises(ValueError):
+            _ = BoundingBox(self.xLim, self.yLim, self.zLim)
+
     def testGivenLimits_whenAskingLimits_shouldReturnCorrectLimits(self):
         bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
+
         self.assertEqual(bbox.xLim, self.xLim)
         self.assertEqual(bbox.yLim, self.yLim)
         self.assertEqual(bbox.zLim, self.zLim)
 
     def testGivenLimits_whenAskingMinMax_shouldReturnMinMax(self):
         bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
+
         self.assertEqual(bbox.xMin, self.xLim[0])
         self.assertEqual(bbox.xMax, self.xLim[1])
         self.assertEqual(bbox.yMin, self.yLim[0])
@@ -29,19 +36,15 @@ class TestBoundingBox(unittest.TestCase):
         self.assertEqual(bbox.zMin, self.zLim[0])
         self.assertEqual(bbox.zMax, self.zLim[1])
 
-    def testGivenVertices_whenAskingLimits_shouldReturnCorrectLimits(self):
+    def testGivenNewBBoxFromVertices_whenAskingLimits_shouldReturnCorrectLimits(self):
         v1 = Vector(0, 1, 0)
         v2 = Vector(-1, 1, 2)
         v3 = Vector(-0.1, -1, 3.001)
         bbox = BoundingBox.fromVertices([v1, v2, v3])
+
         self.assertEqual(bbox.xLim, [-1, 0])
         self.assertEqual(bbox.yLim, [-1, 1])
         self.assertEqual(bbox.zLim, [0, 3.001])
-
-    def testGivenWrongLimits_whenInit_shouldReturnMinMax(self):
-        self.zLim = [0.5, -0.5]
-        with self.assertRaises(ValueError):
-            _ = BoundingBox(self.xLim, self.yLim, self.zLim)
 
     def testGivenLimits_whenChangeLimits_shouldReturnNewLimits(self):
         bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
@@ -53,12 +56,12 @@ class TestBoundingBox(unittest.TestCase):
         with self.assertRaises(ValueError):
             bbox.change("x", "max", -1)
 
-    def testGiven2SimilarBBox_whenEquals_returnsTrue(self):
+    def testGiven2SimilarBBox_whenEquals_shouldReturnTrue(self):
         bbox1 = BoundingBox(self.xLim, self.yLim, self.zLim)
         bbox2 = BoundingBox(self.xLim, self.yLim, self.zLim)
         self.assertTrue(bbox1 == bbox2)
 
-    def testGiven2DifferentBBox_whenEquals_returnsFalse(self):
+    def testGiven2DifferentBBox_whenEquals_shouldReturnFalse(self):
         bbox1 = BoundingBox(self.xLim, self.yLim, self.zLim)
         bbox2 = BoundingBox([0, 1.001], self.yLim, self.zLim)
         self.assertTrue(bbox1 != bbox2)

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -4,30 +4,30 @@ from pytissueoptics.scene.geometry import BoundingBox, Vector
 
 
 class TestBoundingBox(unittest.TestCase):
+    
+    def setUp(self):
+        self.xLim = [0, 1]
+        self.yLim = [-1, 0]
+        self.zLim = [-0.5, 0.5]
+    
     def testWhenCreatedEmpty_shouldRaiseException(self):
         with self.assertRaises(Exception):
             _ = BoundingBox()
 
     def testGivenLimits_whenAskingLimits_shouldReturnCorrectLimits(self):
-        xLim = [0, 1]
-        yLim = [-1, 0]
-        zLim = [0.5, -0.5]
-        bbox = BoundingBox(xLim, yLim, zLim)
-        self.assertEqual(bbox.xLim, xLim)
-        self.assertEqual(bbox.yLim, yLim)
-        self.assertEqual(bbox.zLim, zLim)
+        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
+        self.assertEqual(bbox.xLim, self.xLim)
+        self.assertEqual(bbox.yLim, self.yLim)
+        self.assertEqual(bbox.zLim, self.zLim)
 
     def testGivenLimits_whenAskingMinMax_shouldReturnMinMax(self):
-        xLim = [0, 1]
-        yLim = [-1, 0]
-        zLim = [-0.5, 0.5]
-        bbox = BoundingBox(xLim, yLim, zLim)
-        self.assertEqual(bbox.xMin, xLim[0])
-        self.assertEqual(bbox.xMax, xLim[1])
-        self.assertEqual(bbox.yMin, yLim[0])
-        self.assertEqual(bbox.yMax, yLim[1])
-        self.assertEqual(bbox.zMin, zLim[0])
-        self.assertEqual(bbox.zMax, zLim[1])
+        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
+        self.assertEqual(bbox.xMin, self.xLim[0])
+        self.assertEqual(bbox.xMax, self.xLim[1])
+        self.assertEqual(bbox.yMin, self.yLim[0])
+        self.assertEqual(bbox.yMax, self.yLim[1])
+        self.assertEqual(bbox.zMin, self.zLim[0])
+        self.assertEqual(bbox.zMax, self.zLim[1])
 
     def testGivenVertices_whenAskingLimits_shouldReturnCorrectLimits(self):
         v1 = Vector(0, 1, 0)
@@ -39,10 +39,16 @@ class TestBoundingBox(unittest.TestCase):
         self.assertEqual(bbox.zLim, [0, 3.001])
 
     def testGivenWrongLimits_whenInit_shouldReturnMinMax(self):
-        xLim = [0, 1]
-        yLim = [-1, 0]
-        zLim = [0.5, -0.5]
+        self.zLim = [0.5, -0.5]
         with self.assertRaises(ValueError):
-            _ = BoundingBox(xLim, yLim, zLim)
+            _ = BoundingBox(self.xLim, self.yLim, self.zLim)
 
-    
+    def testGivenLimits_whenChangeLimits_shouldReturnNewLimits(self):
+        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
+        bbox.change("x", "max", 3)
+        self.assertEqual(bbox.xMax, 3)
+
+    def testGivenLimits_whenChangeToWrongLimits_shouldRaiseValueError(self):
+        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
+        with self.assertRaises(ValueError):
+            bbox.change("x", "max", -1)

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -52,3 +52,16 @@ class TestBoundingBox(unittest.TestCase):
         bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
         with self.assertRaises(ValueError):
             bbox.change("x", "max", -1)
+
+    def testGivenLimits_whenChangeToNew_shouldReturnNewLimits(self):
+        oldBbox = BoundingBox(self.xLim, self.yLim, self.zLim)
+        newBbox = oldBbox.changeToNew("x", "max", 3)
+        
+        self.assertEqual(oldBbox.xMax, 1)
+        self.assertEqual(newBbox.xMax, 3)
+
+    def testGivenLimits_whenChangeToNewWrongLimits_shouldRaiseValueError(self):
+        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
+        with self.assertRaises(ValueError):
+            bbox.changeToNew("x", "max", -1)
+

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -65,3 +65,12 @@ class TestBoundingBox(unittest.TestCase):
         with self.assertRaises(ValueError):
             bbox.changeToNew("x", "max", -1)
 
+    def testGiven2SimilarBBox_whenEquals_returnsTrue(self):
+        bbox1 = BoundingBox(self.xLim, self.yLim, self.zLim)
+        bbox2 = BoundingBox(self.xLim, self.yLim, self.zLim)
+        self.assertTrue(bbox1 == bbox2)
+
+    def testGiven2DifferentBBox_whenEquals_returnsFalse(self):
+        bbox1 = BoundingBox(self.xLim, self.yLim, self.zLim)
+        bbox2 = BoundingBox([0, 1.001], self.yLim, self.zLim)
+        self.assertTrue(bbox1 != bbox2)

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -28,3 +28,13 @@ class TestBoundingBox(unittest.TestCase):
         bbox1 = BoundingBox(self.xLim, self.yLim, self.zLim)
         bbox2 = BoundingBox([0, 1.001], self.yLim, self.zLim)
         self.assertTrue(bbox1 != bbox2)
+
+    def testGivenNewBBoxFromVertices_shouldDefineBoundingBoxAroundVertices(self):
+        v1 = Vector(0, 1, 0)
+        v2 = Vector(-1, 1, 2)
+        v3 = Vector(-0.1, -1, 3.001)
+        bbox = BoundingBox.fromVertices([v1, v2, v3])
+
+        self.assertEqual(bbox.xLim, [-1, 0])
+        self.assertEqual(bbox.yLim, [-1, 1])
+        self.assertEqual(bbox.zLim, [0, 3.001])

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -53,18 +53,6 @@ class TestBoundingBox(unittest.TestCase):
         with self.assertRaises(ValueError):
             bbox.change("x", "max", -1)
 
-    def testGivenLimits_whenChangeToNew_shouldReturnNewLimits(self):
-        oldBbox = BoundingBox(self.xLim, self.yLim, self.zLim)
-        newBbox = oldBbox.changeToNew("x", "max", 3)
-        
-        self.assertEqual(oldBbox.xMax, 1)
-        self.assertEqual(newBbox.xMax, 3)
-
-    def testGivenLimits_whenChangeToNewWrongLimits_shouldRaiseValueError(self):
-        bbox = BoundingBox(self.xLim, self.yLim, self.zLim)
-        with self.assertRaises(ValueError):
-            bbox.changeToNew("x", "max", -1)
-
     def testGiven2SimilarBBox_whenEquals_returnsTrue(self):
         bbox1 = BoundingBox(self.xLim, self.yLim, self.zLim)
         bbox2 = BoundingBox(self.xLim, self.yLim, self.zLim)

--- a/pytissueoptics/scene/tests/geometry/testTriangle.py
+++ b/pytissueoptics/scene/tests/geometry/testTriangle.py
@@ -4,6 +4,16 @@ from pytissueoptics.scene.geometry import Triangle, Vector
 
 
 class TestTriangle(unittest.TestCase):
-    def testWhenCreated_shouldDefineItsNormal(self):
+    def testGivenANewTriangle_shouldDefineItsNormal(self):
         triangle = Triangle(v1=Vector(0, 0, 0), v2=Vector(2, 0, 0), v3=Vector(2, 2, 0))
         self.assertEqual(Vector(0, 0, 1), triangle.normal)
+
+    def testGivenANewTriangle_whenModifyingVertex_resetBoundingBoxShouldChangeBbox(self):
+        triangle = Triangle(v1=Vector(0, 0, 0), v2=Vector(2, 0, 0), v3=Vector(2, 2, 0))
+        oldBbox = triangle.bbox
+
+        triangle.vertices[0].update(1, 1, 1)
+        triangle.resetBoundingBox()
+        newBbox = triangle.bbox
+
+        self.assertNotEqual(oldBbox, newBbox)

--- a/pytissueoptics/scene/tests/solids/testSolid.py
+++ b/pytissueoptics/scene/tests/solids/testSolid.py
@@ -78,3 +78,38 @@ class TestSolid(unittest.TestCase):
         solid.rotate(xTheta=90, yTheta=90, zTheta=90)
 
         verify(polygon, times=1).resetNormal()
+
+    def testWhenRotate_shouldChangeBboxOfSolidAndPolygons(self):
+        polygon = mock(Polygon)
+        when(polygon).resetNormal().thenReturn()
+        when(polygon).resetBoundingBox().thenReturn()
+        when(polygon).setInsideMaterial(...).thenReturn()
+
+        self.CUBOID_SURFACES.setPolygons('Front', [polygon])
+        solid = Solid(position=self.position, material=self.material, vertices=self.CUBOID_VERTICES,
+                      surfaces=self.CUBOID_SURFACES, primitive=primitives.TRIANGLE)
+        oldBbox = solid.bbox
+        solid.rotate(xTheta=90, yTheta=90, zTheta=90)
+        newBbox = solid.bbox
+
+        # once during the __init__, once during the positioning, once during the rotation = 3
+        verify(polygon, times=3).resetBoundingBox()
+        self.assertNotEqual(oldBbox, newBbox)
+
+
+    def testWhenTranslate_shouldChangeBboxOfSolidAndPolygons(self):
+        polygon = mock(Polygon)
+        when(polygon).resetNormal().thenReturn()
+        when(polygon).resetBoundingBox().thenReturn()
+        when(polygon).setInsideMaterial(...).thenReturn()
+
+        self.CUBOID_SURFACES.setPolygons('Front', [polygon])
+        solid = Solid(position=self.position, material=self.material, vertices=self.CUBOID_VERTICES,
+                      surfaces=self.CUBOID_SURFACES, primitive=primitives.TRIANGLE)
+        oldBbox = solid.bbox
+        solid.translateTo(Vector(1, -1, -1))
+        newBbox = solid.bbox
+
+        # once during the __init__, once during the positioning, once during the translation = 3
+        verify(polygon, times=3).resetBoundingBox()
+        self.assertNotEqual(oldBbox, newBbox)

--- a/pytissueoptics/scene/tests/solids/testSolid.py
+++ b/pytissueoptics/scene/tests/solids/testSolid.py
@@ -68,9 +68,7 @@ class TestSolid(unittest.TestCase):
         self.assertAlmostEqual(expectedRotatedVertex5.z, self.CUBOID_VERTICES[5].z)
 
     def testWhenRotate_shouldRotateItsPolygons(self):
-        polygon = mock(Polygon)
-        when(polygon).resetNormal().thenReturn()
-        when(polygon).setInsideMaterial(...).thenReturn()
+        polygon = self.createPolygonMock()
         self.CUBOID_SURFACES.setPolygons('Front', [polygon])
         solid = Solid(position=self.position, material=self.material, vertices=self.CUBOID_VERTICES,
                       surfaces=self.CUBOID_SURFACES, primitive=primitives.TRIANGLE)
@@ -79,37 +77,36 @@ class TestSolid(unittest.TestCase):
 
         verify(polygon, times=1).resetNormal()
 
-    def testWhenRotate_shouldChangeBboxOfSolidAndPolygons(self):
-        polygon = mock(Polygon)
-        when(polygon).resetNormal().thenReturn()
-        when(polygon).resetBoundingBox().thenReturn()
-        when(polygon).setInsideMaterial(...).thenReturn()
-
+    def testWhenRotate_shouldRotateBBoxOfSolidAndPolygons(self):
+        polygon = self.createPolygonMock()
         self.CUBOID_SURFACES.setPolygons('Front', [polygon])
         solid = Solid(position=self.position, material=self.material, vertices=self.CUBOID_VERTICES,
                       surfaces=self.CUBOID_SURFACES, primitive=primitives.TRIANGLE)
         oldBbox = solid.bbox
+
         solid.rotate(xTheta=90, yTheta=90, zTheta=90)
-        newBbox = solid.bbox
 
         # once during the __init__, once during the positioning, once during the rotation = 3
         verify(polygon, times=3).resetBoundingBox()
-        self.assertNotEqual(oldBbox, newBbox)
+        self.assertNotEqual(oldBbox, solid.bbox)
 
-
-    def testWhenTranslate_shouldChangeBboxOfSolidAndPolygons(self):
-        polygon = mock(Polygon)
-        when(polygon).resetNormal().thenReturn()
-        when(polygon).resetBoundingBox().thenReturn()
-        when(polygon).setInsideMaterial(...).thenReturn()
-
+    def testWhenTranslate_shouldTranslateBBoxOfSolidAndPolygons(self):
+        polygon = self.createPolygonMock()
         self.CUBOID_SURFACES.setPolygons('Front', [polygon])
         solid = Solid(position=self.position, material=self.material, vertices=self.CUBOID_VERTICES,
                       surfaces=self.CUBOID_SURFACES, primitive=primitives.TRIANGLE)
         oldBbox = solid.bbox
+
         solid.translateTo(Vector(1, -1, -1))
-        newBbox = solid.bbox
 
         # once during the __init__, once during the positioning, once during the translation = 3
         verify(polygon, times=3).resetBoundingBox()
-        self.assertNotEqual(oldBbox, newBbox)
+        self.assertNotEqual(oldBbox, solid.bbox)
+
+    @staticmethod
+    def createPolygonMock() -> Polygon:
+        polygon = mock(Polygon)
+        when(polygon).resetNormal().thenReturn()
+        when(polygon).resetBoundingBox().thenReturn()
+        when(polygon).setInsideMaterial(...).thenReturn()
+        return polygon


### PR DESCRIPTION
A `BoundingBox` is necessary to rapidly know the 3d extent of a structure, wheter it is a polygon, a solid or a scene.

The `BoundingBox` is analogous to the cuboid, it has x, y and z values.
It cannot interpret or nuance for any curve-like object, thus cannot be directly used to know if an object contains another. 

The `BoundingBox` will be used for raytracing/intersections calculations and for the object-search algorithms