### PR TITLE
Solid insertion

### DIFF
--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -80,10 +80,3 @@ class BoundingBox:
 
     def __getitem__(self, index: int) -> List[float]:
         return self._xyzLimits[index]
-
-    def getVertices(self) -> List[Vector]:
-        vertices = []
-        for (i, j, k) in itertools.product(range(2), repeat=3):
-            x, y, z = self._xLim[i], self._yLim[j], self._zLim[k]
-            vertices.append(Vector(x, y, z))
-        return vertices

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -1,4 +1,3 @@
-import itertools
 from typing import List
 
 from pytissueoptics.scene.geometry import Vector

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -1,3 +1,4 @@
+import itertools
 from typing import List
 
 from pytissueoptics.scene.geometry import Vector
@@ -79,3 +80,10 @@ class BoundingBox:
 
     def __getitem__(self, index: int) -> List[float]:
         return self._xyzLimits[index]
+
+    def getVertices(self) -> List[Vector]:
+        vertices = []
+        for (i, j, k) in itertools.product(range(2), repeat=3):
+            x, y, z = self._xLim[i], self._yLim[j], self._zLim[k]
+            vertices.append(Vector(x, y, z))
+        return vertices

--- a/pytissueoptics/scene/geometry/polygon.py
+++ b/pytissueoptics/scene/geometry/polygon.py
@@ -64,3 +64,10 @@ class Polygon:
         N = edgeA.cross(edgeB)
         N.normalize()
         self._normal = N
+
+    def getCentroid(self) -> Vector:
+        centroid = Vector(0, 0, 0)
+        for vertex in self._vertices:
+            centroid.add(vertex)
+        centroid.divide(len(self._vertices))
+        return centroid

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -22,6 +22,9 @@ class Scene:
         if len(intersectingSuspects) == 0:
             return
         if len(intersectingSuspects) != 1:
+            # todo: if multiple suspects, they should already be well contained.
+            #  so we can scan from smallest to biggest and see if it can fit between adjacent solids
+            #  with s, a, b. s has to be in a or a in s and s in b else increment
             raise NotImplementedError("Cannot handle placement of a solid that intersects with more than one solid. ")
 
         otherSolid = intersectingSuspects[0]

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -6,13 +6,15 @@ from pytissueoptics.scene.solids import Solid
 
 
 class Scene:
-    def __init__(self):
+    def __init__(self, ignoreIntersections=False):
         self._solids = []
+        self._ignoreIntersections = ignoreIntersections
 
     def add(self, solid: Solid, position: Vector = None):
         if position:
             solid.translateTo(position)
-        self._validate(solid)
+        if not self._ignoreIntersections:
+            self._validate(solid)
         self._solids.append(solid)
 
     def _validate(self, newSolid: Solid):

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -32,9 +32,11 @@ class Scene:
         solidUpdates: Dict[Solid, Material] = {}
         for otherSolid in intersectingSuspects:
             if newSolid.contains(*otherSolid.getVertices()):
+                self._assertIsNotAStack(newSolid)
                 solidUpdates[otherSolid] = newSolid.getMaterial()
                 break
             elif otherSolid.contains(*newSolid.getVertices()):
+                self._assertIsNotAStack(otherSolid)
                 solidUpdates[newSolid] = otherSolid.getMaterial()
             else:
                 raise NotImplementedError("Cannot place a solid that partially intersects with an existing solid. ")
@@ -51,3 +53,8 @@ class Scene:
                 if suspectBBox[axis][0] > solidBBox[axis][1] or suspectBBox[axis][1] < solidBBox[axis][0]:
                     intersectingSuspects.remove(suspect)
         return intersectingSuspects
+
+    @staticmethod
+    def _assertIsNotAStack(solid: Solid):
+        if solid.isStack():
+            raise NotImplementedError("Cannot place a solid inside a solid stack. ")

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -1,8 +1,44 @@
 from typing import List
 
+from pytissueoptics.scene.geometry import Vector
 from pytissueoptics.scene.solids import Solid
 
 
 class Scene:
-    def __init__(self, solids: List[Solid]):
-        self.solids = solids
+    def __init__(self):
+        self._solids = []
+
+    def add(self, solid: Solid, position: Vector = None):
+        if position:
+            solid.translateTo(position)
+        self._validate(solid)
+        self._solids.append(solid)
+
+    def _validate(self, solid: Solid):
+        if len(self._solids) == 0:
+            return
+
+        intersectingSuspects = self._findIntersectingSuspectsFor(solid)
+        if len(intersectingSuspects) == 0:
+            return
+        if len(intersectingSuspects) != 1:
+            raise NotImplementedError("Cannot handle placement of a solid that intersects with more than one solid. ")
+
+        otherSolid = intersectingSuspects[0]
+        # fixme: or change for more precise/slower contains(solid.vertices)
+        if solid.contains(*otherSolid.getBoundingBox().getVertices()):
+            otherSolid.setOutsideMaterial(solid.getMaterial())
+        elif otherSolid.contains(*solid.getBoundingBox().getVertices()):
+            solid.setOutsideMaterial(otherSolid.getMaterial())
+        else:
+            raise NotImplementedError("Cannot place a solid that partially intersects with an existing solid. ")
+
+    def _findIntersectingSuspectsFor(self, solid) -> List[Solid]:
+        solidBBox = solid.getBoundingBox()
+        intersectingSuspects = self._solids
+        for axis in range(3):
+            for suspect in intersectingSuspects:
+                suspectBBox = suspect.getBoundingBox()
+                if suspectBBox[axis][0] > solidBBox[axis][1] or suspectBBox[axis][1] < solidBBox[axis][0]:
+                    intersectingSuspects.remove(suspect)
+        return intersectingSuspects

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -25,10 +25,9 @@ class Scene:
             raise NotImplementedError("Cannot handle placement of a solid that intersects with more than one solid. ")
 
         otherSolid = intersectingSuspects[0]
-        # fixme: or change for more precise/slower contains(solid.vertices)
-        if solid.contains(*otherSolid.getBoundingBox().getVertices()):
+        if solid.contains(*otherSolid.getVertices()):
             otherSolid.setOutsideMaterial(solid.getMaterial())
-        elif otherSolid.contains(*solid.getBoundingBox().getVertices()):
+        elif otherSolid.contains(*solid.getVertices()):
             solid.setOutsideMaterial(otherSolid.getMaterial())
         else:
             raise NotImplementedError("Cannot place a solid that partially intersects with an existing solid. ")

--- a/pytissueoptics/scene/solids/cuboid.py
+++ b/pytissueoptics/scene/solids/cuboid.py
@@ -28,10 +28,10 @@ class Cuboid(Solid):
         self.shape = [a, b, c]
 
         if not vertices:
-            vertices = [Vector(-a / 2, -b / 2, -c / 2), Vector(a / 2, -b / 2, -c / 2), Vector(a / 2, b / 2, -c / 2),
-                        Vector(-a / 2, b / 2, -c / 2),
-                        Vector(-a / 2, -b / 2, c / 2), Vector(a / 2, -b / 2, c / 2), Vector(a / 2, b / 2, c / 2),
-                        Vector(-a / 2, b / 2, c / 2)]
+            vertices = [Vector(-a / 2, -b / 2, c / 2), Vector(a / 2, -b / 2, c / 2), Vector(a / 2, b / 2, c / 2),
+                        Vector(-a / 2, b / 2, c / 2),
+                        Vector(-a / 2, -b / 2, -c / 2), Vector(a / 2, -b / 2, -c / 2), Vector(a / 2, b / 2, -c / 2),
+                        Vector(-a / 2, b / 2, -c / 2)]
 
         super().__init__(vertices, position, surfaces, material, primitive)
 

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -146,3 +146,9 @@ class Solid:
 
     def contains(self, *vertices: Vector) -> bool:
         raise NotImplementedError
+
+    def isStack(self) -> bool:
+        for surfaceName in self.surfaceNames:
+            if "Interface" in surfaceName:
+                return True
+        return False

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -46,6 +46,9 @@ class Solid:
     def bbox(self) -> BoundingBox:
         return self._bbox
 
+    def getBoundingBox(self) -> BoundingBox:
+        return self.bbox
+
     def _resetBoundingBox(self):
         self._bbox = BoundingBox.fromVertices(self._vertices)
         self._surfaces.resetBoundingBoxes()

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -49,6 +49,9 @@ class Solid:
     def getBoundingBox(self) -> BoundingBox:
         return self.bbox
 
+    def getVertices(self) -> List[Vector]:
+        return self.vertices
+
     def _resetBoundingBox(self):
         self._bbox = BoundingBox.fromVertices(self._vertices)
         self._surfaces.resetBoundingBoxes()

--- a/pytissueoptics/scene/solids/sphere.py
+++ b/pytissueoptics/scene/solids/sphere.py
@@ -1,4 +1,4 @@
-from pytissueoptics.scene.geometry import Vector, Triangle
+from pytissueoptics.scene.geometry import Vector
 from pytissueoptics.scene.geometry import primitives
 from pytissueoptics.scene.materials import Material
 from pytissueoptics.scene.solids import Ellipsoid

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -110,8 +110,14 @@ class TestScene(unittest.TestCase):
         verify(SOLID).setOutsideMaterial(OUTSIDE_SOLID_MATERIAL)
         verify(INSIDE_SOLID).setOutsideMaterial(SOLID_MATERIAL)
 
-    def testWhenAddingASolidInsideACuboidStack_shouldRaiseNotImplementedError(self):
-        pass
+    def testWhenAddingASolidInsideASolidStack_shouldRaiseNotImplementedError(self):
+        CUBOID_STACK = self.makeSolidWith(BoundingBox([1, 4], [1, 4], [1, 4]), contains=True, isStack=True)
+        self.scene.add(CUBOID_STACK)
+
+        INSIDE_SOLID = self.makeSolidWith(BoundingBox([2, 3], [2, 3], [2, 3]))
+
+        with self.assertRaises(NotImplementedError):
+            self.scene.add(INSIDE_SOLID)
 
     def testGivenASceneThatIgnoresIntersections_whenAddingASolidThatPartlyMergesWithAnotherOne_shouldAddTheSolid(self):
         scene = Scene(ignoreIntersections=True)
@@ -122,9 +128,10 @@ class TestScene(unittest.TestCase):
         scene.add(SOLID)
 
     @staticmethod
-    def makeSolidWith(bbox: BoundingBox, contains=False):
+    def makeSolidWith(bbox: BoundingBox, contains=False, isStack=False):
         solid = mock(Solid)
         when(solid).getBoundingBox().thenReturn(bbox)
+        when(solid).isStack().thenReturn(isStack)
         when(solid).getVertices().thenReturn([])
         when(solid).setOutsideMaterial(...).thenReturn()
         when(solid).getMaterial().thenReturn(Material())

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -21,3 +21,7 @@ class TestScene(unittest.TestCase):
 
     def testWhenAddingASolidInsideACuboidStack_shouldRaiseNotImplementedError(self):
         pass
+
+    def testGivenASceneWithOnlyReflectiveRaytracing_whenAddingASolidThatPartlyMergesWithAnotherOne_shouldAddTheSolidToTheSceneWithoutAffectingExistingSolid(self):
+        # better support for constructive geometry?
+        pass

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -1,22 +1,66 @@
 import unittest
 
+from mockito import mock, verify, when
+
+from pytissueoptics.scene import Material
+from pytissueoptics.scene.scene import Scene
+from pytissueoptics.scene.geometry import Vector, BoundingBox
+from pytissueoptics.scene.solids import Solid
+
 
 class TestScene(unittest.TestCase):
-    def testWhenAddingASolid_shouldAddItToTheSceneAtTheDesiredPosition(self):
-        pass
+    THE_POSITION = Vector(4, 0, 1)
 
-    def testWhenAddingASolidWithNonZeroPositionToADesiredPosition_shouldWarnAboutRepositioning(self):
-        pass
+    def setUp(self):
+        self.scene = Scene()
+
+    def testWhenAddingASolidAtAPosition_shouldPlaceTheSolidAtTheDesiredPosition(self):
+        THE_SOLID = mock(Solid)
+        when(THE_SOLID).translateTo(...).thenReturn()
+
+        self.scene.add(THE_SOLID, position=self.THE_POSITION)
+
+        verify(THE_SOLID).translateTo(self.THE_POSITION)
+
+    def testWhenAddingASolidAtNoSpecificPosition_shouldKeepTheSolidAtItsPredefinedPosition(self):
+        THE_SOLID = mock(Solid)
+        when(THE_SOLID).translateTo(...).thenReturn()
+
+        self.scene.add(THE_SOLID)
+
+        verify(THE_SOLID, times=0).translateTo(...)
+
+    def testWhenAddingASolidThatPartlyOverlapsWithAnotherOne_shouldNotAdd(self):
+        otherBBox = BoundingBox([2, 5], [2, 5], [2, 5])
+        OTHER_SOLID = mock(Solid, {"bbox": otherBBox})
+        solidBBox = BoundingBox([0, 3], [0, 3], [0, 3])
+        THE_SOLID = mock(Solid, {"bbox": solidBBox})
+        self.scene.add(OTHER_SOLID)
+
+        with self.assertRaises(Exception):
+            self.scene.add(THE_SOLID)
 
     def testWhenAddingASolidInsideAnotherOne_shouldUpdateOutsideMaterialOfThisSolid(self):
-        # when adding solid, check for intersections (if 2 bbox touches,
-        # assert one is contained in the other and update outside material)
-        pass
+        OTHER_SOLID = mock(Solid)
+        otherBBox = BoundingBox([0, 5], [0, 5], [0, 5])
+        otherMaterial = Material()
+        when(OTHER_SOLID).getBoundingBox().thenReturn(otherBBox)
+        when(OTHER_SOLID).getMaterial().thenReturn(otherMaterial)
+        self.scene.add(OTHER_SOLID)
+
+        THE_SOLID = mock(Solid)
+        solidBBox = BoundingBox([1, 3], [1, 3], [1, 3])
+        when(THE_SOLID).getBoundingBox().thenReturn(solidBBox)
+        when(THE_SOLID).setOutsideMaterial(...).thenReturn()
+
+        when(OTHER_SOLID).contains(...).thenReturn(True)
+        when(THE_SOLID).contains(...).thenReturn(False)
+
+        self.scene.add(THE_SOLID)
+
+        verify(THE_SOLID).setOutsideMaterial(otherMaterial)
 
     def testWhenAddingASolidOverAnotherOne_shouldUpdateOutsideMaterialOfTheOtherSolid(self):
-        pass
-
-    def testWhenAddingASolidThatPartlyMergesWithAnotherOne_shouldNotAdd(self):
         pass
 
     def testWhenAddingASolidInsideACuboidStack_shouldRaiseNotImplementedError(self):

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -31,43 +31,60 @@ class TestScene(unittest.TestCase):
         verify(THE_SOLID, times=0).translateTo(...)
 
     def testWhenAddingASolidThatPartlyOverlapsWithAnotherOne_shouldNotAdd(self):
-        otherBBox = BoundingBox([2, 5], [2, 5], [2, 5])
-        OTHER_SOLID = mock(Solid, {"bbox": otherBBox})
-        solidBBox = BoundingBox([0, 3], [0, 3], [0, 3])
-        THE_SOLID = mock(Solid, {"bbox": solidBBox})
+        OTHER_SOLID = self.makeSolidWithBBox(BoundingBox([2, 5], [2, 5], [2, 5]))
+        THE_SOLID = self.makeSolidWithBBox(BoundingBox([0, 3], [0, 3], [0, 3]))
         self.scene.add(OTHER_SOLID)
 
         with self.assertRaises(Exception):
             self.scene.add(THE_SOLID)
 
     def testWhenAddingASolidInsideAnotherOne_shouldUpdateOutsideMaterialOfThisSolid(self):
-        OTHER_SOLID = mock(Solid)
-        otherBBox = BoundingBox([0, 5], [0, 5], [0, 5])
+        OTHER_SOLID = self.makeSolidWithBBox(BoundingBox([0, 5], [0, 5], [0, 5]))
+        THE_SOLID = self.makeSolidWithBBox(BoundingBox([1, 3], [1, 3], [1, 3]))
         otherMaterial = Material()
-        when(OTHER_SOLID).getBoundingBox().thenReturn(otherBBox)
         when(OTHER_SOLID).getMaterial().thenReturn(otherMaterial)
-        when(OTHER_SOLID).getVertices().thenReturn([])
-        self.scene.add(OTHER_SOLID)
-
-        THE_SOLID = mock(Solid)
-        solidBBox = BoundingBox([1, 3], [1, 3], [1, 3])
-        when(THE_SOLID).getBoundingBox().thenReturn(solidBBox)
-        when(THE_SOLID).setOutsideMaterial(...).thenReturn()
-        when(THE_SOLID).getVertices().thenReturn([])
-
         when(OTHER_SOLID).contains(...).thenReturn(True)
         when(THE_SOLID).contains(...).thenReturn(False)
+        self.scene.add(OTHER_SOLID)
 
         self.scene.add(THE_SOLID)
 
         verify(THE_SOLID).setOutsideMaterial(otherMaterial)
 
     def testWhenAddingASolidOverAnotherOne_shouldUpdateOutsideMaterialOfTheOtherSolid(self):
+        OTHER_SOLID = self.makeSolidWithBBox(BoundingBox([0, 5], [0, 5], [0, 5]))
+        THE_SOLID = self.makeSolidWithBBox(BoundingBox([-1, 6], [-1, 6], [-1, 6]))
+        solidMaterial = Material()
+        when(THE_SOLID).getMaterial().thenReturn(solidMaterial)
+        when(OTHER_SOLID).contains(...).thenReturn(False)
+        when(THE_SOLID).contains(...).thenReturn(True)
+        self.scene.add(OTHER_SOLID)
+
+        self.scene.add(THE_SOLID)
+
+        verify(OTHER_SOLID).setOutsideMaterial(solidMaterial)
+
+    def testWhenAddingASolidInsideMultipleOtherSolids_shouldUpdateOutsideMaterialOfThisSolid(self):
+        pass
+
+    def testWhenAddingASolidOverMultipleOtherSolids_shouldUpdateOutsideMaterialOfTheTopMostSolid(self):
+        pass
+
+    def testWhenAddingASolidThatFitsInsideOneButAlsoContainsOne_shouldUpdateOutsideMaterialOfThisSolidAndTheOneInside(self):
         pass
 
     def testWhenAddingASolidInsideACuboidStack_shouldRaiseNotImplementedError(self):
         pass
 
-    def testGivenASceneWithOnlyReflectiveRaytracing_whenAddingASolidThatPartlyMergesWithAnotherOne_shouldAddTheSolidToTheSceneWithoutAffectingExistingSolid(self):
+    def testGivenASceneWithOnlyReflectiveRaytracing_whenAddingASolidThatPartlyMergesWithAnotherOne_shouldAddTheSolid(self):
         # better support for constructive geometry?
         pass
+
+    @staticmethod
+    def makeSolidWithBBox(bbox: BoundingBox):
+        solid = mock(Solid)
+        when(solid).getBoundingBox().thenReturn(bbox)
+        when(solid).getVertices().thenReturn([])
+        when(solid).setOutsideMaterial(...).thenReturn()
+        when(solid).getVertices().thenReturn([])
+        return solid

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -113,9 +113,13 @@ class TestScene(unittest.TestCase):
     def testWhenAddingASolidInsideACuboidStack_shouldRaiseNotImplementedError(self):
         pass
 
-    def testGivenASceneWithOnlyReflectiveRaytracing_whenAddingASolidThatPartlyMergesWithAnotherOne_shouldAddTheSolid(self):
-        # better support for constructive geometry?
-        pass
+    def testGivenASceneThatIgnoresIntersections_whenAddingASolidThatPartlyMergesWithAnotherOne_shouldAddTheSolid(self):
+        scene = Scene(ignoreIntersections=True)
+        OTHER_SOLID = self.makeSolidWith(BoundingBox([2, 5], [2, 5], [2, 5]))
+        SOLID = self.makeSolidWith(BoundingBox([0, 3], [0, 3], [0, 3]))
+        scene.add(OTHER_SOLID)
+
+        scene.add(SOLID)
 
     @staticmethod
     def makeSolidWith(bbox: BoundingBox, contains=False):

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -46,12 +46,14 @@ class TestScene(unittest.TestCase):
         otherMaterial = Material()
         when(OTHER_SOLID).getBoundingBox().thenReturn(otherBBox)
         when(OTHER_SOLID).getMaterial().thenReturn(otherMaterial)
+        when(OTHER_SOLID).getVertices().thenReturn([])
         self.scene.add(OTHER_SOLID)
 
         THE_SOLID = mock(Solid)
         solidBBox = BoundingBox([1, 3], [1, 3], [1, 3])
         when(THE_SOLID).getBoundingBox().thenReturn(solidBBox)
         when(THE_SOLID).setOutsideMaterial(...).thenReturn()
+        when(THE_SOLID).getVertices().thenReturn([])
 
         when(OTHER_SOLID).contains(...).thenReturn(True)
         when(THE_SOLID).contains(...).thenReturn(False)

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -9,69 +9,106 @@ from pytissueoptics.scene.solids import Solid
 
 
 class TestScene(unittest.TestCase):
-    THE_POSITION = Vector(4, 0, 1)
-
     def setUp(self):
         self.scene = Scene()
 
     def testWhenAddingASolidAtAPosition_shouldPlaceTheSolidAtTheDesiredPosition(self):
-        THE_SOLID = mock(Solid)
-        when(THE_SOLID).translateTo(...).thenReturn()
+        SOLID_POSITION = Vector(4, 0, 1)
+        SOLID = mock(Solid)
+        when(SOLID).translateTo(...).thenReturn()
 
-        self.scene.add(THE_SOLID, position=self.THE_POSITION)
+        self.scene.add(SOLID, position=SOLID_POSITION)
 
-        verify(THE_SOLID).translateTo(self.THE_POSITION)
+        verify(SOLID).translateTo(SOLID_POSITION)
 
     def testWhenAddingASolidAtNoSpecificPosition_shouldKeepTheSolidAtItsPredefinedPosition(self):
-        THE_SOLID = mock(Solid)
-        when(THE_SOLID).translateTo(...).thenReturn()
+        SOLID = mock(Solid)
+        when(SOLID).translateTo(...).thenReturn()
 
-        self.scene.add(THE_SOLID)
+        self.scene.add(SOLID)
 
-        verify(THE_SOLID, times=0).translateTo(...)
+        verify(SOLID, times=0).translateTo(...)
 
     def testWhenAddingASolidThatPartlyOverlapsWithAnotherOne_shouldNotAdd(self):
-        OTHER_SOLID = self.makeSolidWithBBox(BoundingBox([2, 5], [2, 5], [2, 5]))
-        THE_SOLID = self.makeSolidWithBBox(BoundingBox([0, 3], [0, 3], [0, 3]))
+        OTHER_SOLID = self.makeSolidWith(BoundingBox([2, 5], [2, 5], [2, 5]))
+        SOLID = self.makeSolidWith(BoundingBox([0, 3], [0, 3], [0, 3]))
         self.scene.add(OTHER_SOLID)
 
         with self.assertRaises(Exception):
-            self.scene.add(THE_SOLID)
+            self.scene.add(SOLID)
 
     def testWhenAddingASolidInsideAnotherOne_shouldUpdateOutsideMaterialOfThisSolid(self):
-        OTHER_SOLID = self.makeSolidWithBBox(BoundingBox([0, 5], [0, 5], [0, 5]))
-        THE_SOLID = self.makeSolidWithBBox(BoundingBox([1, 3], [1, 3], [1, 3]))
-        otherMaterial = Material()
-        when(OTHER_SOLID).getMaterial().thenReturn(otherMaterial)
-        when(OTHER_SOLID).contains(...).thenReturn(True)
-        when(THE_SOLID).contains(...).thenReturn(False)
-        self.scene.add(OTHER_SOLID)
+        OUTSIDE_SOLID = self.makeSolidWith(BoundingBox([0, 5], [0, 5], [0, 5]), contains=True)
+        SOLID = self.makeSolidWith(BoundingBox([1, 3], [1, 3], [1, 3]))
+        OUTSIDE_SOLID_MATERIAL = Material()
+        when(OUTSIDE_SOLID).getMaterial().thenReturn(OUTSIDE_SOLID_MATERIAL)
+        self.scene.add(OUTSIDE_SOLID)
 
-        self.scene.add(THE_SOLID)
+        self.scene.add(SOLID)
 
-        verify(THE_SOLID).setOutsideMaterial(otherMaterial)
+        verify(SOLID).setOutsideMaterial(OUTSIDE_SOLID_MATERIAL)
 
     def testWhenAddingASolidOverAnotherOne_shouldUpdateOutsideMaterialOfTheOtherSolid(self):
-        OTHER_SOLID = self.makeSolidWithBBox(BoundingBox([0, 5], [0, 5], [0, 5]))
-        THE_SOLID = self.makeSolidWithBBox(BoundingBox([-1, 6], [-1, 6], [-1, 6]))
-        solidMaterial = Material()
-        when(THE_SOLID).getMaterial().thenReturn(solidMaterial)
-        when(OTHER_SOLID).contains(...).thenReturn(False)
-        when(THE_SOLID).contains(...).thenReturn(True)
-        self.scene.add(OTHER_SOLID)
+        INSIDE_SOLID = self.makeSolidWith(BoundingBox([0, 5], [0, 5], [0, 5]))
+        self.scene.add(INSIDE_SOLID)
 
-        self.scene.add(THE_SOLID)
+        SOLID = self.makeSolidWith(BoundingBox([-1, 6], [-1, 6], [-1, 6]), contains=True)
+        SOLID_MATERIAL = Material()
+        when(SOLID).getMaterial().thenReturn(SOLID_MATERIAL)
 
-        verify(OTHER_SOLID).setOutsideMaterial(solidMaterial)
+        self.scene.add(SOLID)
+
+        verify(INSIDE_SOLID).setOutsideMaterial(SOLID_MATERIAL)
 
     def testWhenAddingASolidInsideMultipleOtherSolids_shouldUpdateOutsideMaterialOfThisSolid(self):
-        pass
+        OUTSIDE_SOLID = self.makeSolidWith(BoundingBox([1, 4], [1, 4], [1, 4]))
+        OUTSIDE_SOLID_MATERIAL = Material()
+        when(OUTSIDE_SOLID).getMaterial().thenReturn(OUTSIDE_SOLID_MATERIAL)
+        self.scene.add(OUTSIDE_SOLID)
+
+        TOPMOST_OUTSIDE_SOLID = self.makeSolidWith(BoundingBox([0, 5], [0, 5], [0, 5]), contains=True)
+        self.scene.add(TOPMOST_OUTSIDE_SOLID)
+
+        SOLID = self.makeSolidWith(BoundingBox([2, 3], [2, 3], [2, 3]))
+        when(OUTSIDE_SOLID).contains(...).thenReturn(True)
+
+        self.scene.add(SOLID)
+
+        verify(SOLID).setOutsideMaterial(OUTSIDE_SOLID_MATERIAL)
 
     def testWhenAddingASolidOverMultipleOtherSolids_shouldUpdateOutsideMaterialOfTheTopMostSolid(self):
-        pass
+        TOPMOST_INSIDE_SOLID = self.makeSolidWith(BoundingBox([0, 5], [0, 5], [0, 5]), contains=True)
+        self.scene.add(TOPMOST_INSIDE_SOLID)
+
+        INSIDE_SOLID = self.makeSolidWith(BoundingBox([1, 4], [1, 4], [1, 4]))
+        self.scene.add(INSIDE_SOLID)
+
+        SOLID = self.makeSolidWith(BoundingBox([-1, 6], [-1, 6], [-1, 6]), contains=True)
+        SOLID_MATERIAL = Material()
+        when(SOLID).getMaterial().thenReturn(SOLID_MATERIAL)
+
+        self.scene.add(SOLID)
+
+        verify(TOPMOST_INSIDE_SOLID).setOutsideMaterial(SOLID_MATERIAL)
 
     def testWhenAddingASolidThatFitsInsideOneButAlsoContainsOne_shouldUpdateOutsideMaterialOfThisSolidAndTheOneInside(self):
-        pass
+        INSIDE_SOLID = self.makeSolidWith(BoundingBox([2, 3], [2, 3], [2, 3]))
+        self.scene.add(INSIDE_SOLID)
+
+        OUTSIDE_SOLID = self.makeSolidWith(BoundingBox([0, 5], [0, 5], [0, 5]), contains=True)
+        OUTSIDE_SOLID_MATERIAL = Material()
+        when(OUTSIDE_SOLID).getMaterial().thenReturn(OUTSIDE_SOLID_MATERIAL)
+        self.scene.add(OUTSIDE_SOLID)
+
+        SOLID = self.makeSolidWith(BoundingBox([1, 4], [1, 4], [1, 4]))
+        SOLID_MATERIAL = Material()
+        when(SOLID).getMaterial().thenReturn(SOLID_MATERIAL)
+        when(SOLID).contains(...).thenReturn(False).thenReturn(True)
+
+        self.scene.add(SOLID)
+
+        verify(SOLID).setOutsideMaterial(OUTSIDE_SOLID_MATERIAL)
+        verify(INSIDE_SOLID).setOutsideMaterial(SOLID_MATERIAL)
 
     def testWhenAddingASolidInsideACuboidStack_shouldRaiseNotImplementedError(self):
         pass
@@ -81,10 +118,12 @@ class TestScene(unittest.TestCase):
         pass
 
     @staticmethod
-    def makeSolidWithBBox(bbox: BoundingBox):
+    def makeSolidWith(bbox: BoundingBox, contains=False):
         solid = mock(Solid)
         when(solid).getBoundingBox().thenReturn(bbox)
         when(solid).getVertices().thenReturn([])
         when(solid).setOutsideMaterial(...).thenReturn()
+        when(solid).getMaterial().thenReturn(Material())
         when(solid).getVertices().thenReturn([])
+        when(solid).contains(...).thenReturn(contains)
         return solid

--- a/pytissueoptics/scene/tests/solids/testSolid.py
+++ b/pytissueoptics/scene/tests/solids/testSolid.py
@@ -103,6 +103,13 @@ class TestSolid(unittest.TestCase):
         verify(polygon, times=3).resetBoundingBox()
         self.assertNotEqual(oldBbox, solid.bbox)
 
+    def testShouldNotBeAStack(self):
+        self.assertFalse(self.solid.isStack())
+
+    def testGivenASolidWithInterfaces_shouldBeAStack(self):
+        self.solid.surfaces.add("Interface0", [])
+        self.assertTrue(self.solid.isStack())
+
     @staticmethod
     def createPolygonMock() -> Polygon:
         polygon = mock(Polygon)

--- a/pytissueoptics/scene/tests/testScene.py
+++ b/pytissueoptics/scene/tests/testScene.py
@@ -1,0 +1,23 @@
+import unittest
+
+
+class TestScene(unittest.TestCase):
+    def testWhenAddingASolid_shouldAddItToTheSceneAtTheDesiredPosition(self):
+        pass
+
+    def testWhenAddingASolidWithNonZeroPositionToADesiredPosition_shouldWarnAboutRepositioning(self):
+        pass
+
+    def testWhenAddingASolidInsideAnotherOne_shouldUpdateOutsideMaterialOfThisSolid(self):
+        # when adding solid, check for intersections (if 2 bbox touches,
+        # assert one is contained in the other and update outside material)
+        pass
+
+    def testWhenAddingASolidOverAnotherOne_shouldUpdateOutsideMaterialOfTheOtherSolid(self):
+        pass
+
+    def testWhenAddingASolidThatPartlyMergesWithAnotherOne_shouldNotAdd(self):
+        pass
+
+    def testWhenAddingASolidInsideACuboidStack_shouldRaiseNotImplementedError(self):
+        pass

--- a/pytissueoptics/scene/tests/viewer/testMayaviSolid.py
+++ b/pytissueoptics/scene/tests/viewer/testMayaviSolid.py
@@ -26,3 +26,16 @@ class TestMayaviSolid(unittest.TestCase):
         self.assertEqual([0, 0, 1, 1], x)
         self.assertEqual(len(solid.getPolygons()), len(polygonIndices))
         self.assertEqual((2, 3, 0), polygonIndices[1])
+
+    def testGivenNewMayaviSolidWithLoadNormals_shouldExtractMayaviNormalsFromSolid(self):
+        solid = self.createSimpleSolid()
+        mayaviSolid = MayaviSolid(solid, loadNormals=True)
+
+        normals = mayaviSolid.normals
+        x, y, z, u, v, w = normals.components
+        self.assertEqual(len(solid.getPolygons()), len(x))
+        self.assertTrue(len(x) == len(y) == len(z) == len(u) == len(v) == len(w))
+
+        for i, polygon in enumerate(self.surfaces.getPolygons()):
+            self.assertEqual([x[i], y[i], z[i]], polygon.getCentroid().array)
+            self.assertEqual([u[i], v[i], w[i]], polygon.normal.array)

--- a/pytissueoptics/scene/viewer/mayavi/MayaviNormals.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviNormals.py
@@ -1,0 +1,27 @@
+from pytissueoptics.scene.geometry import Vector
+
+
+class MayaviNormals:
+    def __init__(self):
+        self._x = []
+        self._y = []
+        self._z = []
+
+        self._u = []
+        self._v = []
+        self._w = []
+
+    def add(self, position: Vector, direction: Vector):
+        x, y, z = position.array
+        self._x.append(x)
+        self._y.append(y)
+        self._z.append(z)
+
+        u, v, w = direction.array
+        self._u.append(u)
+        self._v.append(v)
+        self._w.append(w)
+
+    @property
+    def components(self) -> tuple:
+        return self._x, self._y, self._z, self._u, self._v, self._w

--- a/pytissueoptics/scene/viewer/mayavi/MayaviSolid.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviSolid.py
@@ -2,16 +2,19 @@ from typing import List, Tuple
 
 from pytissueoptics.scene.solids import Solid
 from pytissueoptics.scene.viewer.mayavi import MayaviMesh
+from pytissueoptics.scene.viewer.mayavi.MayaviNormals import MayaviNormals
 
 
 class MayaviSolid:
-    def __init__(self, solid: 'Solid'):
+    def __init__(self, solid: 'Solid', loadNormals=True):
         self._solid = solid
         self._primitive = solid.primitive
         self._x = []
         self._y = []
         self._z = []
         self._polygonIndices: List[Tuple[int]] = []
+        self._loadNormals = loadNormals
+        self._normals = MayaviNormals()
 
         self._create()
 
@@ -37,6 +40,13 @@ class MayaviSolid:
                 polygonIndices.append(index)
             self._polygonIndices.append(tuple(polygonIndices))
 
+            if self._loadNormals:
+                self._normals.add(polygon.getCentroid(), polygon.normal)
+
     @property
     def mesh(self) -> MayaviMesh:
         return MayaviMesh(self._x, self._y, self._z, self._polygonIndices)
+
+    @property
+    def normals(self) -> MayaviNormals:
+        return self._normals

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -14,13 +14,15 @@ class MayaviViewer:
         self._view = {"azimuth": 0, "zenith": 0, "distance": None, "pointingTowards": None, "roll": None}
         self.clear()
 
-    def add(self, *solids: 'Solid', representation="wireframe", lineWidth=0.25):
+    def add(self, *solids: 'Solid', representation="wireframe", lineWidth=0.25, showNormals=False, normalLength=0.3):
         for solid in solids:
             assert solid.primitive == primitives.TRIANGLE, "MavaviViewer currently only supports triangle mesh. "
-            mayaviSolid = MayaviSolid(solid)
+            mayaviSolid = MayaviSolid(solid, loadNormals=showNormals)
             self._scenes["DefaultScene"]["Solids"].append(mayaviSolid)
             mlab.triangular_mesh(*mayaviSolid.mesh.components, representation=representation, line_width=lineWidth,
                                  colormap="viridis")
+            if showNormals:
+                mlab.quiver3d(*mayaviSolid.normals.components, line_width=lineWidth, scale_factor=normalLength, color=(1, 1, 1))
 
     def _assignViewPoint(self):
         azimuth, elevation, distance, towards, roll = (self._view[key] for key in self._view)
@@ -48,5 +50,5 @@ if __name__ == "__main__":
     sphere1 = Sphere(order=2)
     cuboid1 = Cuboid(1, 3, 3, position=Vector(4, 0, 0))
     viewer = MayaviViewer()
-    viewer.add(sphere1, cuboid1)
+    viewer.add(sphere1, cuboid1, lineWidth=1, showNormals=True)
     viewer.show()


### PR DESCRIPTION
Using the Scene API, when you add a solid to the scene, it will check if it intersects with an existing solid. If the new solid is fully contained by an existing solid it will set its outside material for this container's inside material. Similar logic if the new solid contains an existing solid. It supports nested insertions.

It will raise a **NotImplementedError** for the following cases:
- The new solid partially intersects with an existing solid. 
- Trying to add a solid inside a solid stack (Cuboid Stack).

If you are not interested in correcting surface materials, this validation can be turned off by using `Scene(ignoreIntersections=True)`, which is enough to do simple (reflective) raytracing. 