### PR TITLE
Allow display of normals

### DIFF
--- a/pytissueoptics/scene/geometry/polygon.py
+++ b/pytissueoptics/scene/geometry/polygon.py
@@ -64,3 +64,10 @@ class Polygon:
         N = edgeA.cross(edgeB)
         N.normalize()
         self._normal = N
+
+    def getCentroid(self) -> Vector:
+        centroid = Vector(0, 0, 0)
+        for vertex in self._vertices:
+            centroid.add(vertex)
+        centroid.divide(len(self._vertices))
+        return centroid

--- a/pytissueoptics/scene/solids/cuboid.py
+++ b/pytissueoptics/scene/solids/cuboid.py
@@ -28,10 +28,10 @@ class Cuboid(Solid):
         self.shape = [a, b, c]
 
         if not vertices:
-            vertices = [Vector(-a / 2, -b / 2, -c / 2), Vector(a / 2, -b / 2, -c / 2), Vector(a / 2, b / 2, -c / 2),
-                        Vector(-a / 2, b / 2, -c / 2),
-                        Vector(-a / 2, -b / 2, c / 2), Vector(a / 2, -b / 2, c / 2), Vector(a / 2, b / 2, c / 2),
-                        Vector(-a / 2, b / 2, c / 2)]
+            vertices = [Vector(-a / 2, -b / 2, c / 2), Vector(a / 2, -b / 2, c / 2), Vector(a / 2, b / 2, c / 2),
+                        Vector(-a / 2, b / 2, c / 2),
+                        Vector(-a / 2, -b / 2, -c / 2), Vector(a / 2, -b / 2, -c / 2), Vector(a / 2, b / 2, -c / 2),
+                        Vector(-a / 2, b / 2, -c / 2)]
 
         super().__init__(vertices, position, surfaces, material, primitive)
 

--- a/pytissueoptics/scene/solids/ellipsoid.py
+++ b/pytissueoptics/scene/solids/ellipsoid.py
@@ -103,6 +103,7 @@ class Ellipsoid(Solid):
             r = self._radiusTowards(vertex)
             distanceFromUnitSphere = (r - 1.0)
             vertex.add(vertex * distanceFromUnitSphere)
+        self.surfaces.resetNormals()
 
     @staticmethod
     def _findThetaPhi(vertex: 'Vector'):

--- a/pytissueoptics/scene/tests/viewer/testMayaviSolid.py
+++ b/pytissueoptics/scene/tests/viewer/testMayaviSolid.py
@@ -26,3 +26,16 @@ class TestMayaviSolid(unittest.TestCase):
         self.assertEqual([0, 0, 1, 1], x)
         self.assertEqual(len(solid.getPolygons()), len(polygonIndices))
         self.assertEqual((2, 3, 0), polygonIndices[1])
+
+    def testGivenNewMayaviSolidWithLoadNormals_shouldExtractMayaviNormalsFromSolid(self):
+        solid = self.createSimpleSolid()
+        mayaviSolid = MayaviSolid(solid, loadNormals=True)
+
+        normals = mayaviSolid.normals
+        x, y, z, u, v, w = normals.components
+        self.assertEqual(len(solid.getPolygons()), len(x))
+        self.assertTrue(len(x) == len(y) == len(z) == len(u) == len(v) == len(w))
+
+        for i, polygon in enumerate(self.surfaces.getPolygons()):
+            self.assertEqual([x[i], y[i], z[i]], polygon.getCentroid().array)
+            self.assertEqual([u[i], v[i], w[i]], polygon.normal.array)

--- a/pytissueoptics/scene/viewer/mayavi/MayaviNormals.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviNormals.py
@@ -1,0 +1,27 @@
+from pytissueoptics.scene.geometry import Vector
+
+
+class MayaviNormals:
+    def __init__(self):
+        self._x = []
+        self._y = []
+        self._z = []
+
+        self._u = []
+        self._v = []
+        self._w = []
+
+    def add(self, position: Vector, direction: Vector):
+        x, y, z = position.array
+        self._x.append(x)
+        self._y.append(y)
+        self._z.append(z)
+
+        u, v, w = direction.array
+        self._u.append(u)
+        self._v.append(v)
+        self._w.append(w)
+
+    @property
+    def components(self) -> tuple:
+        return self._x, self._y, self._z, self._u, self._v, self._w

--- a/pytissueoptics/scene/viewer/mayavi/MayaviSolid.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviSolid.py
@@ -2,16 +2,19 @@ from typing import List, Tuple
 
 from pytissueoptics.scene.solids import Solid
 from pytissueoptics.scene.viewer.mayavi import MayaviMesh
+from pytissueoptics.scene.viewer.mayavi.MayaviNormals import MayaviNormals
 
 
 class MayaviSolid:
-    def __init__(self, solid: 'Solid'):
+    def __init__(self, solid: 'Solid', loadNormals=True):
         self._solid = solid
         self._primitive = solid.primitive
         self._x = []
         self._y = []
         self._z = []
         self._polygonIndices: List[Tuple[int]] = []
+        self._loadNormals = loadNormals
+        self._normals = MayaviNormals()
 
         self._create()
 
@@ -37,6 +40,13 @@ class MayaviSolid:
                 polygonIndices.append(index)
             self._polygonIndices.append(tuple(polygonIndices))
 
+            if self._loadNormals:
+                self._normals.add(polygon.getCentroid(), polygon.normal)
+
     @property
     def mesh(self) -> MayaviMesh:
         return MayaviMesh(self._x, self._y, self._z, self._polygonIndices)
+
+    @property
+    def normals(self) -> MayaviNormals:
+        return self._normals

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -14,13 +14,15 @@ class MayaviViewer:
         self._view = {"azimuth": 0, "zenith": 0, "distance": None, "pointingTowards": None, "roll": None}
         self.clear()
 
-    def add(self, *solids: 'Solid', representation="wireframe", lineWidth=0.25):
+    def add(self, *solids: 'Solid', representation="wireframe", lineWidth=0.25, showNormals=False, normalLength=0.3):
         for solid in solids:
             assert solid.primitive == primitives.TRIANGLE, "MavaviViewer currently only supports triangle mesh. "
-            mayaviSolid = MayaviSolid(solid)
+            mayaviSolid = MayaviSolid(solid, loadNormals=showNormals)
             self._scenes["DefaultScene"]["Solids"].append(mayaviSolid)
             mlab.triangular_mesh(*mayaviSolid.mesh.components, representation=representation, line_width=lineWidth,
                                  colormap="viridis")
+            if showNormals:
+                mlab.quiver3d(*mayaviSolid.normals.components, line_width=lineWidth, scale_factor=normalLength, color=(1, 1, 1))
 
     def _assignViewPoint(self):
         azimuth, elevation, distance, towards, roll = (self._view[key] for key in self._view)
@@ -48,5 +50,5 @@ if __name__ == "__main__":
     sphere1 = Sphere(order=2)
     cuboid1 = Cuboid(1, 3, 3, position=Vector(4, 0, 0))
     viewer = MayaviViewer()
-    viewer.add(sphere1, cuboid1)
+    viewer.add(sphere1, cuboid1, lineWidth=1, showNormals=True)
     viewer.show()


### PR DESCRIPTION
Optional in `viewer.add(solid, showNormals=False, normalLength=0.3)`.
I'm open for suggestions for this interface and its default values. 

Fixed normal orientation of cuboid polygons (reversed). 
Fixed normal orientation of ellipsoids (reset polygon normals after moving vertices to unit sphere during creation)

![image](https://user-images.githubusercontent.com/29587649/154192126-b52c020b-0256-4bfa-818f-14a25264c7d9.png)