### PR TITLE
Logger

### DIFF
--- a/pytissueoptics/scene/logger/__init__.py
+++ b/pytissueoptics/scene/logger/__init__.py
@@ -1,0 +1,1 @@
+from .logger import Logger

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -62,3 +62,21 @@ class Logger:
     def logSegment(self, start: Vector, end: Vector):
         self._segments.append(Segment(start, end))
 
+
+if __name__ == '__main__':
+    from pytissueoptics.scene.viewer.mayavi import MayaviViewer
+    from pytissueoptics.scene import Sphere
+
+    logger = Logger()
+    for i in range(10):
+        logger.logPoint(Vector(i, i/2, 0))
+        logger.logDataPoint(i, Vector(i, i, 0))
+        logger.logSegment(Vector(10, 10, 0), Vector(10+(2*i), 0, 0))
+
+    viewer = MayaviViewer()
+
+    sphere1 = Sphere(radius=2, order=2, position=Vector(-2, 2, 0))
+    viewer.add(sphere1, lineWidth=1)
+
+    viewer.addLogger(logger)
+    viewer.show()

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -35,24 +35,6 @@ class Logger:
     def segments(self):
         return self._segments
 
-    def getMinDataPoint(self) -> DataPoint:
-        minDataPoint = None
-        minValue = sys.maxsize
-        for dataPoint in self._dataPoints:
-            if dataPoint.value < minValue:
-                minValue = dataPoint.value
-                minDataPoint = dataPoint
-        return minDataPoint
-
-    def getMaxDataPoint(self) -> DataPoint:
-        maxDataPoint = None
-        maxValue = -sys.maxsize
-        for dataPoint in self._dataPoints:
-            if dataPoint.value > maxValue:
-                maxValue = dataPoint.value
-                maxDataPoint = dataPoint
-        return maxDataPoint
-
     def logPoint(self, point: Vector):
         self._points.append(point)
 

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -1,0 +1,64 @@
+import sys
+from dataclasses import dataclass
+from typing import List
+
+from pytissueoptics.scene.geometry import Vector
+
+
+@dataclass
+class DataPoint:
+    value: float
+    position: Vector
+
+
+@dataclass
+class Segment:
+    start: Vector
+    end: Vector
+
+
+class Logger:
+    def __init__(self):
+        self._points: List[Vector] = []
+        self._dataPoints: List[DataPoint] = []
+        self._segments: List[Segment] = []
+
+    @property
+    def points(self):
+        return self._points
+
+    @property
+    def dataPoints(self):
+        return self._dataPoints
+
+    @property
+    def segments(self):
+        return self._segments
+
+    def getMinDataPoint(self) -> DataPoint:
+        minDataPoint = None
+        minValue = sys.maxsize
+        for dataPoint in self._dataPoints:
+            if dataPoint.value < minValue:
+                minValue = dataPoint.value
+                minDataPoint = dataPoint
+        return minDataPoint
+
+    def getMaxDataPoint(self) -> DataPoint:
+        maxDataPoint = None
+        maxValue = -sys.maxsize
+        for dataPoint in self._dataPoints:
+            if dataPoint.value > maxValue:
+                maxValue = dataPoint.value
+                maxDataPoint = dataPoint
+        return maxDataPoint
+
+    def logPoint(self, point: Vector):
+        self._points.append(point)
+
+    def logDataPoint(self, value: float, position: Vector):
+        self._dataPoints.append(DataPoint(value, position))
+
+    def logSegment(self, start: Vector, end: Vector):
+        self._segments.append(Segment(start, end))
+

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -1,4 +1,3 @@
-import sys
 from dataclasses import dataclass
 from typing import List
 
@@ -46,14 +45,13 @@ class Logger:
 
 
 if __name__ == '__main__':
-    from pytissueoptics.scene.viewer.mayavi import MayaviViewer
-    from pytissueoptics.scene import Sphere
+    from pytissueoptics.scene import Sphere, Vector, MayaviViewer
 
     logger = Logger()
     for i in range(10):
-        logger.logPoint(Vector(i, i/2, 0))
+        logger.logPoint(Vector(i, i / 2, 0))
         logger.logDataPoint(i, Vector(i, i, 0))
-        logger.logSegment(Vector(10, 10, 0), Vector(10+(2*i), 0, 0))
+        logger.logSegment(Vector(10, 10, 0), Vector(10 + (2 * i), 0, 0))
 
     viewer = MayaviViewer()
 

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -6,9 +6,13 @@ from pytissueoptics.scene.solids import Solid
 
 
 class Scene:
-    def __init__(self, ignoreIntersections=False):
+    def __init__(self, solids: list = None, ignoreIntersections=False):
         self._solids = []
         self._ignoreIntersections = ignoreIntersections
+
+        if solids:
+            for solid in solids:
+                self.add(solid)
 
     def add(self, solid: Solid, position: Vector = None):
         if position:
@@ -16,6 +20,10 @@ class Scene:
         if not self._ignoreIntersections:
             self._validate(solid)
         self._solids.append(solid)
+
+    @property
+    def solids(self):
+        return self._solids
 
     def _validate(self, newSolid: Solid):
         """ Assert newSolid position is valid and make proper adjustments so that the

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -109,11 +109,12 @@ class Solid:
     def setPolygons(self, surfaceName: str, polygons: List[Polygon]):
         self._surfaces.setPolygons(surfaceName, polygons)
 
+        currentVerticesIDs = {id(vertex) for vertex in self._vertices}
         newVertices = []
         for polygon in polygons:
             newVertices.extend(polygon.vertices)
         for vertex in newVertices:
-            if vertex not in self._vertices:
+            if id(vertex) not in currentVerticesIDs:
                 self._vertices.append(vertex)
 
     @property

--- a/pytissueoptics/scene/solids/stack/cuboidStacker.py
+++ b/pytissueoptics/scene/solids/stack/cuboidStacker.py
@@ -36,6 +36,10 @@ class CuboidStacker:
     def _getSurfaceAxis(self, surfaceName: str) -> int:
         return max(axis if surfaceName in surfacePair else -1 for axis, surfacePair in enumerate(self.SURFACE_PAIRS))
 
+    @property
+    def _stackingTowardsPositive(self) -> bool:
+        return self.SURFACE_PAIRS[self._stackAxis].index(self._onSurfaceName) == 1
+
     def _getOppositeSurface(self, surfaceName: str) -> str:
         onSurfaceIndex = self.SURFACE_PAIRS[self._stackAxis].index(surfaceName)
         return self.SURFACE_PAIRS[self._stackAxis][(onSurfaceIndex + 1) % 2]
@@ -53,8 +57,7 @@ class CuboidStacker:
                                             self._otherCuboid.shape[self._stackAxis] / 2
         relativePosition = Vector(*relativePosition)
 
-        towardsPositive = self.SURFACE_PAIRS[self._stackAxis].index(self._onSurfaceName)
-        if not towardsPositive:
+        if not self._stackingTowardsPositive:
             relativePosition.multiply(-1)
 
         self._otherCuboid.translateTo(self._onCuboid.position + relativePosition)
@@ -83,7 +86,10 @@ class CuboidStacker:
     def _getStackPosition(self):
         relativeStackCentroid = [0, 0, 0]
         relativeStackCentroid[self._stackAxis] = self._otherCuboid.shape[self._stackAxis] / 2
-        return self._onCuboid.position + Vector(*relativeStackCentroid)
+        relativeStackCentroid = Vector(*relativeStackCentroid)
+        if not self._stackingTowardsPositive:
+            relativeStackCentroid.multiply(-1)
+        return self._onCuboid.position + relativeStackCentroid
 
     def _getStackVertices(self):
         stackVertices = self._onCuboid.vertices

--- a/pytissueoptics/scene/solids/stack/cuboidStacker.py
+++ b/pytissueoptics/scene/solids/stack/cuboidStacker.py
@@ -93,7 +93,8 @@ class CuboidStacker:
 
     def _getStackVertices(self):
         stackVertices = self._onCuboid.vertices
-        newVertices = [vertex for vertex in self._otherCuboid.vertices if vertex not in self._onCuboid.vertices]
+        onCuboidVerticesIDs = {id(vertex) for vertex in self._onCuboid.vertices}
+        newVertices = [vertex for vertex in self._otherCuboid.vertices if id(vertex) not in onCuboidVerticesIDs]
         stackVertices.extend(newVertices)
         return stackVertices
 

--- a/pytissueoptics/scene/tests/geometry/testVector.py
+++ b/pytissueoptics/scene/tests/geometry/testVector.py
@@ -107,3 +107,8 @@ class TestVector(unittest.TestCase):
         newVector = self.vector.copy()
         newVector.add(Vector(1, 1, 1))
         self.assertNotEqual(newVector, self.vector)
+
+    def testWhenCheckIfAnotherVectorWithTheSameCoordinatesIsContained_shouldReturnTrue(self):
+        vector = Vector(0, 0, 0)
+        listOfOtherVectors = [Vector(0, 0, 0)]
+        self.assertTrue(vector in listOfOtherVectors)

--- a/pytissueoptics/scene/tests/logger/testLogger.py
+++ b/pytissueoptics/scene/tests/logger/testLogger.py
@@ -44,25 +44,3 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(3, len(logger.segments))
         self.assertEqual(Vector(0, 0, 0), logger.segments[-1].start)
         self.assertEqual(Vector(1, 0, 0), logger.segments[-1].end)
-
-    def testGivenLoggerWithMultipleDataPoints_whenGetMinDataPoint_shouldReturnDataPointWithMinimumValue(self):
-        logger = Logger()
-        logger.logDataPoint(-10.5, Vector(0, 0, 0))
-        logger.logDataPoint(10, Vector(2, 0, 0))
-        logger.logDataPoint(20.5, Vector(1, 0, 0))
-
-        minDataPoint = logger.getMinDataPoint()
-
-        self.assertEqual(-10.5, minDataPoint.value)
-        self.assertEqual(Vector(0, 0, 0), minDataPoint.position)
-
-    def testGivenLoggerWithMultipleDataPoints_whenGetMaxDataPoint_shouldReturnDataPointWithMaximumValue(self):
-        logger = Logger()
-        logger.logDataPoint(-10.5, Vector(0, 0, 0))
-        logger.logDataPoint(10, Vector(2, 0, 0))
-        logger.logDataPoint(20.5, Vector(1, 0, 0))
-
-        maxDataPoint = logger.getMaxDataPoint()
-
-        self.assertEqual(20.5, maxDataPoint.value)
-        self.assertEqual(Vector(1, 0, 0), maxDataPoint.position)

--- a/pytissueoptics/scene/tests/logger/testLogger.py
+++ b/pytissueoptics/scene/tests/logger/testLogger.py
@@ -1,0 +1,68 @@
+import unittest
+
+from pytissueoptics.scene.geometry import Vector
+from pytissueoptics.scene.logger import Logger
+
+
+class TestLogger(unittest.TestCase):
+    def testGivenNewLogger_shouldBeEmpty(self):
+        logger = Logger()
+
+        self.assertEqual(0, len(logger.points))
+        self.assertEqual(0, len(logger.dataPoints))
+        self.assertEqual(0, len(logger.segments))
+
+    def testWhenLogNewPoint_shouldAddPointToTheLoggedPoints(self):
+        logger = Logger()
+        logger.logPoint(Vector(0, 0, 0))
+        logger.logPoint(Vector(1, 0, 0))
+        newPoint = Vector(2, 0, 0)
+
+        logger.logPoint(newPoint)
+
+        self.assertEqual(3, len(logger.points))
+        self.assertEqual(newPoint, logger.points[-1])
+
+    def testWhenLogNewDataPoint_shouldAddDataPointToTheLoggedDataPoints(self):
+        logger = Logger()
+        logger.logDataPoint(-10.5, Vector(0, 0, 0))
+        logger.logDataPoint(20.5, Vector(1, 0, 0))
+
+        logger.logDataPoint(10, Vector(2, 0, 0))
+
+        self.assertEqual(3, len(logger.dataPoints))
+        self.assertEqual(10, logger.dataPoints[-1].value)
+        self.assertEqual(Vector(2, 0, 0), logger.dataPoints[-1].position)
+
+    def testWhenLogNewSegment_shouldAddSegmentToTheLoggedSegments(self):
+        logger = Logger()
+        logger.logSegment(Vector(0, 0, 0), Vector(0, 0, 1))
+        logger.logSegment(Vector(0, 0, 0), Vector(0, 1, 0))
+
+        logger.logSegment(Vector(0, 0, 0), Vector(1, 0, 0))
+
+        self.assertEqual(3, len(logger.segments))
+        self.assertEqual(Vector(0, 0, 0), logger.segments[-1].start)
+        self.assertEqual(Vector(1, 0, 0), logger.segments[-1].end)
+
+    def testGivenLoggerWithMultipleDataPoints_whenGetMinDataPoint_shouldReturnDataPointWithMinimumValue(self):
+        logger = Logger()
+        logger.logDataPoint(-10.5, Vector(0, 0, 0))
+        logger.logDataPoint(10, Vector(2, 0, 0))
+        logger.logDataPoint(20.5, Vector(1, 0, 0))
+
+        minDataPoint = logger.getMinDataPoint()
+
+        self.assertEqual(-10.5, minDataPoint.value)
+        self.assertEqual(Vector(0, 0, 0), minDataPoint.position)
+
+    def testGivenLoggerWithMultipleDataPoints_whenGetMaxDataPoint_shouldReturnDataPointWithMaximumValue(self):
+        logger = Logger()
+        logger.logDataPoint(-10.5, Vector(0, 0, 0))
+        logger.logDataPoint(10, Vector(2, 0, 0))
+        logger.logDataPoint(20.5, Vector(1, 0, 0))
+
+        maxDataPoint = logger.getMaxDataPoint()
+
+        self.assertEqual(20.5, maxDataPoint.value)
+        self.assertEqual(Vector(1, 0, 0), maxDataPoint.position)

--- a/pytissueoptics/scene/tests/solids/testCuboid.py
+++ b/pytissueoptics/scene/tests/solids/testCuboid.py
@@ -84,10 +84,10 @@ class TestCuboid(unittest.TestCase):
         baseCuboid = Cuboid(5, 3, 4, position=basePosition)
         otherCuboid = Cuboid(5, 1, 4)
 
-        cuboidStack = baseCuboid.stack(otherCuboid, onSurface='Top')
+        cuboidStack = baseCuboid.stack(otherCuboid, onSurface='Bottom')
 
         self.assertEqual([5, 4, 4], cuboidStack.shape)
-        self.assertEqual(basePosition + Vector(0, 0.5, 0), cuboidStack.position)
+        self.assertEqual(basePosition - Vector(0, 0.5, 0), cuboidStack.position)
 
     def testWhenStack_shouldReturnANewCuboidWithAFirstInterface(self):
         baseCuboid = Cuboid(5, 3, 4)

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -20,14 +20,15 @@ class MayaviViewer:
         self.clear()
 
     def add(self, *solids: 'Solid', representation="wireframe", lineWidth=0.25, showNormals=False, normalLength=0.3,
-            colormap="viridis", reverseColormap=False, lutMode="auto"):
+            colormap="viridis", reverseColormap=False, constantColor=False):
         for solid in solids:
             mayaviSolid = MayaviSolid(solid, loadNormals=showNormals)
             self._scenes["DefaultScene"]["Solids"].append(mayaviSolid)
             s = mlab.triangular_mesh(*mayaviSolid.triangleMesh.components, representation=representation, line_width=lineWidth,
                                      colormap=colormap)
             s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
-            s.module_manager.lut_data_mode = lutMode
+            if constantColor:
+                s.module_manager.lut_data_mode = "cell data"
             if showNormals:
                 mlab.quiver3d(*mayaviSolid.normals.components, line_width=lineWidth, scale_factor=normalLength, color=(1, 1, 1))
 
@@ -41,7 +42,7 @@ class MayaviViewer:
         x = [vector.x for vector in points]
         y = [vector.y for vector in points]
         z = [vector.z for vector in points]
-        s = mlab.points3d(x, y, z, mode="sphere", scale_factor=0.1, scale_mode="none", colormap=colormap)
+        s = mlab.points3d(x, y, z, mode="sphere", scale_factor=0.08, scale_mode="none", colormap=colormap)
         s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
 
     @staticmethod
@@ -50,7 +51,7 @@ class MayaviViewer:
         y = [dataPoint.position.y for dataPoint in dataPoints]
         z = [dataPoint.position.z for dataPoint in dataPoints]
         v = [dataPoint.value for dataPoint in dataPoints]
-        s = mlab.points3d(x, y, z, v, mode="sphere", scale_factor=0.1, scale_mode="none", colormap=colormap)
+        s = mlab.points3d(x, y, z, v, mode="sphere", scale_factor=0.08, scale_mode="none", colormap=colormap)
         s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
 
     @staticmethod

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -19,39 +19,48 @@ class MayaviViewer:
         self._view = {"azimuth": 0, "zenith": 0, "distance": None, "pointingTowards": None, "roll": None}
         self.clear()
 
-    def add(self, *solids: 'Solid', representation="wireframe", lineWidth=0.25, showNormals=False, normalLength=0.3):
+    def add(self, *solids: 'Solid', representation="wireframe", lineWidth=0.25, showNormals=False, normalLength=0.3,
+            colormap="viridis", reverseColormap=False, lutMode="auto"):
         for solid in solids:
             mayaviSolid = MayaviSolid(solid, loadNormals=showNormals)
             self._scenes["DefaultScene"]["Solids"].append(mayaviSolid)
-            mlab.triangular_mesh(*mayaviSolid.triangleMesh.components, representation=representation, line_width=lineWidth,
-                                 colormap="viridis")
+            s = mlab.triangular_mesh(*mayaviSolid.triangleMesh.components, representation=representation, line_width=lineWidth,
+                                     colormap=colormap)
+            s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
+            s.module_manager.lut_data_mode = lutMode
             if showNormals:
                 mlab.quiver3d(*mayaviSolid.normals.components, line_width=lineWidth, scale_factor=normalLength, color=(1, 1, 1))
 
-    def addLogger(self, logger: Logger):
-        self._addPoints(logger.points)
-        self._addDataPoints(logger.dataPoints)
-        self._addSegments(logger.segments)
+    def addLogger(self, logger: Logger, colormap="rainbow", reverseColormap=False):
+        self._addPoints(logger.points, colormap=colormap, reverseColormap=reverseColormap)
+        self._addDataPoints(logger.dataPoints, colormap=colormap, reverseColormap=reverseColormap)
+        self._addSegments(logger.segments, colormap=colormap, reverseColormap=reverseColormap)
 
-    def _addPoints(self, points: List[Vector]):
+    @staticmethod
+    def _addPoints(points: List[Vector], colormap, reverseColormap):
         x = [vector.x for vector in points]
         y = [vector.y for vector in points]
         z = [vector.z for vector in points]
-        mlab.points3d(x, y, z, mode="sphere", scale_factor=0.1, scale_mode="none")
+        s = mlab.points3d(x, y, z, mode="sphere", scale_factor=0.1, scale_mode="none", colormap=colormap)
+        s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
 
-    def _addDataPoints(self, dataPoints: List[DataPoint]):
+    @staticmethod
+    def _addDataPoints(dataPoints: List[DataPoint], colormap, reverseColormap):
         x = [dataPoint.position.x for dataPoint in dataPoints]
         y = [dataPoint.position.y for dataPoint in dataPoints]
         z = [dataPoint.position.z for dataPoint in dataPoints]
         v = [dataPoint.value for dataPoint in dataPoints]
-        mlab.points3d(x, y, z, v, mode="sphere", scale_factor=0.1, scale_mode="none")
+        s = mlab.points3d(x, y, z, v, mode="sphere", scale_factor=0.1, scale_mode="none", colormap=colormap)
+        s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
 
-    def _addSegments(self, segments: List[Segment]):
+    @staticmethod
+    def _addSegments(segments: List[Segment], colormap, reverseColormap):
         for segment in segments:
             x = [vector.x for vector in [segment.start, segment.end]]
             y = [vector.y for vector in [segment.start, segment.end]]
             z = [vector.z for vector in [segment.start, segment.end]]
-            mlab.plot3d(x, y, z, tube_radius=None, line_width=1)
+            s = mlab.plot3d(x, y, z, tube_radius=None, line_width=1, colormap=colormap)
+            s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
 
     def _assignViewPoint(self):
         azimuth, elevation, distance, towards, roll = (self._view[key] for key in self._view)

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -1,3 +1,8 @@
+from typing import List
+
+from pytissueoptics.scene.logger import Logger
+from pytissueoptics.scene.logger.logger import DataPoint, Segment
+
 try:
     from mayavi import mlab
 except ImportError:
@@ -5,6 +10,7 @@ except ImportError:
 
 from pytissueoptics.scene.viewer.mayavi import MayaviSolid
 from pytissueoptics.scene.solids import Solid
+from pytissueoptics.scene.geometry import Vector
 
 
 class MayaviViewer:
@@ -21,6 +27,31 @@ class MayaviViewer:
                                  colormap="viridis")
             if showNormals:
                 mlab.quiver3d(*mayaviSolid.normals.components, line_width=lineWidth, scale_factor=normalLength, color=(1, 1, 1))
+
+    def addLogger(self, logger: Logger):
+        self._addPoints(logger.points)
+        self._addDataPoints(logger.dataPoints)
+        self._addSegments(logger.segments)
+
+    def _addPoints(self, points: List[Vector]):
+        x = [vector.x for vector in points]
+        y = [vector.y for vector in points]
+        z = [vector.z for vector in points]
+        mlab.points3d(x, y, z, mode="sphere", scale_factor=0.1, scale_mode="none")
+
+    def _addDataPoints(self, dataPoints: List[DataPoint]):
+        x = [dataPoint.position.x for dataPoint in dataPoints]
+        y = [dataPoint.position.y for dataPoint in dataPoints]
+        z = [dataPoint.position.z for dataPoint in dataPoints]
+        v = [dataPoint.value for dataPoint in dataPoints]
+        mlab.points3d(x, y, z, v, mode="sphere", scale_factor=0.1, scale_mode="none")
+
+    def _addSegments(self, segments: List[Segment]):
+        for segment in segments:
+            x = [vector.x for vector in [segment.start, segment.end]]
+            y = [vector.y for vector in [segment.start, segment.end]]
+            z = [vector.z for vector in [segment.start, segment.end]]
+            mlab.plot3d(x, y, z, tube_radius=None, line_width=1)
 
     def _assignViewPoint(self):
         azimuth, elevation, distance, towards, roll = (self._view[key] for key in self._view)

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -15,7 +15,9 @@ from pytissueoptics.scene.geometry import Vector
 
 class MayaviViewer:
     def __init__(self):
-        self._scenes = {"DefaultScene": {"figureParameters": {"bgColor": (0.11, 0.11, 0.11), "fgColor": (0.9, 0.9, 0.9)}, "Solids": [], }}
+        self._scenes = {
+            "DefaultScene": {"figureParameters": {"bgColor": (0.11, 0.11, 0.11), "fgColor": (0.9, 0.9, 0.9)},
+                             "Solids": [], }}
         self._view = {"azimuth": 0, "zenith": 0, "distance": None, "pointingTowards": None, "roll": None}
         self.clear()
 
@@ -24,13 +26,15 @@ class MayaviViewer:
         for solid in solids:
             mayaviSolid = MayaviSolid(solid, loadNormals=showNormals)
             self._scenes["DefaultScene"]["Solids"].append(mayaviSolid)
-            s = mlab.triangular_mesh(*mayaviSolid.triangleMesh.components, representation=representation, line_width=lineWidth,
+            s = mlab.triangular_mesh(*mayaviSolid.triangleMesh.components, representation=representation,
+                                     line_width=lineWidth,
                                      colormap=colormap)
             s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
             if constantColor:
                 s.module_manager.lut_data_mode = "cell data"
             if showNormals:
-                mlab.quiver3d(*mayaviSolid.normals.components, line_width=lineWidth, scale_factor=normalLength, color=(1, 1, 1))
+                mlab.quiver3d(*mayaviSolid.normals.components, line_width=lineWidth, scale_factor=normalLength,
+                              color=(1, 1, 1))
 
     def addLogger(self, logger: Logger, colormap="rainbow", reverseColormap=False):
         self._addPoints(logger.points, colormap=colormap, reverseColormap=reverseColormap)


### PR DESCRIPTION
Very basic logger, or data container. The Mayavi Viewer implements a display of the logger inside `viewer.addLogger()`.
No use cases inside the module itself, but you can log points, data points and segments. This can be useful externally to store and display ray traces and interactions for example. 

### Example

````python
from pytissueoptics.scene import Sphere, Vector, MayaviViewer

logger = Logger()
for i in range(10):
    logger.logPoint(Vector(i, i/2, 0))
    logger.logDataPoint(i, Vector(i, i, 0))
    logger.logSegment(Vector(10, 10, 0), Vector(10+(2*i), 0, 0))

sphere = Sphere(radius=2, order=2, position=Vector(-2, 2, 0))

viewer = MayaviViewer()
viewer.add(sphere, lineWidth=1)
viewer.addLogger(logger)
viewer.show()
````
![image](https://user-images.githubusercontent.com/29587649/155172753-c074bf41-f37d-4b4e-a81a-7c7c0c791c90.png)