### PR TITLE
Allow source in tissue

### DIFF
--- a/pytissueoptics/rayscattering/source.py
+++ b/pytissueoptics/rayscattering/source.py
@@ -1,10 +1,8 @@
 from typing import List
 
-from pytissueoptics.rayscattering.materials import ScatteringMaterial
 from pytissueoptics.rayscattering.tissues.rayScatteringScene import RayScatteringScene
-from pytissueoptics.scene import Vector
 from pytissueoptics.rayscattering.photon import Photon
-from pytissueoptics.scene.geometry import Environment
+from pytissueoptics.scene.geometry import Vector
 from pytissueoptics.scene.intersection import SimpleIntersectionFinder
 from pytissueoptics.scene.logger import Logger
 
@@ -17,12 +15,11 @@ class Source:
 
         self._photons = photons
 
-    def propagate(self, scene: RayScatteringScene, worldMaterial: ScatteringMaterial = ScatteringMaterial(), logger: Logger = None):
+    def propagate(self, scene: RayScatteringScene, logger: Logger = None):
         intersectionFinder = SimpleIntersectionFinder(scene)
-        scene.setOutsideMaterial(worldMaterial)
-        worldEnvironment = Environment(worldMaterial)
+        sourceEnvironment = scene.getEnvironmentAt(self._position)
         for photon in self._photons:
-            photon.setContext(worldEnvironment, intersectionFinder=intersectionFinder, logger=logger)
+            photon.setContext(sourceEnvironment, intersectionFinder=intersectionFinder, logger=logger)
             photon.propagate()
 
     @property

--- a/pytissueoptics/rayscattering/source.py
+++ b/pytissueoptics/rayscattering/source.py
@@ -2,7 +2,7 @@ from typing import List
 
 from pytissueoptics.rayscattering.tissues.rayScatteringScene import RayScatteringScene
 from pytissueoptics.rayscattering.photon import Photon
-from pytissueoptics.scene.geometry import Vector
+from pytissueoptics.scene.geometry import Vector, Environment
 from pytissueoptics.scene.intersection import SimpleIntersectionFinder
 from pytissueoptics.scene.logger import Logger
 
@@ -14,12 +14,14 @@ class Source:
         self._direction.normalize()
 
         self._photons = photons
+        self._environment = None
 
     def propagate(self, scene: RayScatteringScene, logger: Logger = None):
         intersectionFinder = SimpleIntersectionFinder(scene)
-        sourceEnvironment = scene.getEnvironmentAt(self._position)
+        self._environment = scene.getEnvironmentAt(self._position)
+
         for photon in self._photons:
-            photon.setContext(sourceEnvironment, intersectionFinder=intersectionFinder, logger=logger)
+            photon.setContext(self._environment, intersectionFinder=intersectionFinder, logger=logger)
             photon.propagate()
 
     @property
@@ -28,6 +30,14 @@ class Source:
 
     def getPhotonCount(self) -> int:
         return len(self._photons)
+
+    def getPosition(self) -> Vector:
+        return self._position
+
+    def getEnvironment(self) -> Environment:
+        if self._environment is None:
+            return Environment(None)
+        return self._environment
 
 
 class PencilSource(Source):

--- a/pytissueoptics/rayscattering/source.py
+++ b/pytissueoptics/rayscattering/source.py
@@ -2,9 +2,11 @@ from typing import List
 
 from pytissueoptics.rayscattering.tissues.rayScatteringScene import RayScatteringScene
 from pytissueoptics.rayscattering.photon import Photon
+from pytissueoptics.scene.solids import Sphere
 from pytissueoptics.scene.geometry import Vector, Environment
 from pytissueoptics.scene.intersection import SimpleIntersectionFinder
 from pytissueoptics.scene.logger import Logger
+from pytissueoptics.scene.viewer import MayaviViewer
 
 
 class Source:
@@ -38,6 +40,10 @@ class Source:
         if self._environment is None:
             return Environment(None)
         return self._environment
+
+    def addToViewer(self, viewer: MayaviViewer, size: float = 0.1):
+        sphere = Sphere(radius=size/2, position=self._position)
+        viewer.add(sphere, representation="surface", colormap="Wistia", opacity=0.8)
 
 
 class PencilSource(Source):

--- a/pytissueoptics/rayscattering/stats.py
+++ b/pytissueoptics/rayscattering/stats.py
@@ -33,10 +33,12 @@ class PointCloud:
 
 class DisplayConfig:
     """ 3D display configuration dataclass for solid and surface point cloud. """
-    def __init__(self, showScene: bool = True,
+    def __init__(self, showScene: bool = True, showSource: bool = True, sourceSize: float = 0.1,
                  pointSize: float = 0.15, scaleWithValue: bool = True, colormap: str = "rainbow", reverseColormap: bool = False,
                  surfacePointSize: float = 0.01, surfaceScaleWithValue: bool = False, surfaceColormap: str = None, surfaceReverseColormap: bool = None):
         self.showScene = showScene
+        self.showSource = showSource
+        self.sourceSize = sourceSize
 
         self.pointSize = pointSize
         self.scaleWithValue = scaleWithValue
@@ -59,6 +61,7 @@ class Stats:
         solidSource = source.getEnvironment().solid
         self._sourceSolidLabel = solidSource.getLabel() if solidSource else None
         self._photonCount = source.getPhotonCount()
+        self._source = source
 
     def showEnergy3D(self, solidLabel: str = None, surfaceLabel: str = None, config=DisplayConfig()):
         pointCloud = self.getPointCloud(solidLabel, surfaceLabel)
@@ -81,6 +84,9 @@ class Stats:
                 warnings.warn("Cannot display Scene objects when no scene was provided to the Stats.")
             else:
                 self._scene.addToViewer(viewer)
+
+        if config.showSource:
+            self._source.addToViewer(viewer, size=config.sourceSize)
 
         if pointCloud.solidPoints is not None:
             viewer.addDataPoints(pointCloud.solidPoints, scale=config.pointSize,

--- a/pytissueoptics/rayscattering/tests/testSource.py
+++ b/pytissueoptics/rayscattering/tests/testSource.py
@@ -6,36 +6,29 @@ from pytissueoptics.rayscattering import PencilSource, Photon
 from pytissueoptics.rayscattering.materials import ScatteringMaterial
 from pytissueoptics.rayscattering.source import Source
 from pytissueoptics.rayscattering.tissues.rayScatteringScene import RayScatteringScene
-from pytissueoptics.scene import Vector
-from pytissueoptics.scene.geometry import Environment
+from pytissueoptics.scene.geometry import Environment, Vector
 
 
 class TestSource(unittest.TestCase):
+    SOURCE_ENV = Environment(ScatteringMaterial())
+    SOURCE_POSITION = Vector(0, 0, 0)
+
     def setUp(self):
         self.photon = self._createPhoton()
         self.source = Source(position=Vector(), direction=Vector(), photons=[self.photon])
 
-    def testWhenPropagate_shouldSetWorldMaterialInTissue(self):
-        worldMaterial = ScatteringMaterial()
-        tissue = self._createTissue()
-
-        self.source.propagate(tissue, worldMaterial=worldMaterial)
-
-        verify(tissue).setOutsideMaterial(worldMaterial)
-
-    def testWhenPropagate_shouldSetInitialPhotonMaterialAsWorldMaterial(self):
-        worldMaterial = ScatteringMaterial()
-        self.source.propagate(self._createTissue(), worldMaterial=worldMaterial)
-        verify(self.photon).setContext(Environment(worldMaterial), ...)
+    def testWhenPropagate_shouldSetInitialPhotonEnvironmentAsSourceEnvironment(self):
+        self.source.propagate(self._createTissue())
+        verify(self.photon).setContext(self.SOURCE_ENV, ...)
 
     def testWhenPropagate_shouldPropagateAllPhotons(self):
-        self.source.propagate(self._createTissue(), worldMaterial=ScatteringMaterial())
+        self.source.propagate(self._createTissue())
         verify(self.photon).propagate()
 
-    @staticmethod
-    def _createTissue():
+    def _createTissue(self):
         tissue = mock(RayScatteringScene)
-        when(tissue).setOutsideMaterial(...).thenReturn()
+        when(tissue).getEnvironmentAt(self.SOURCE_POSITION).thenReturn(self.SOURCE_ENV)
+        when(tissue).resetOutsideMaterial(...).thenReturn()
         when(tissue).getSolids().thenReturn([])
         return tissue
 

--- a/pytissueoptics/rayscattering/tests/testStats.py
+++ b/pytissueoptics/rayscattering/tests/testStats.py
@@ -17,21 +17,21 @@ class TestStats(unittest.TestCase):
 
     def testWhenGet3DScatter_shouldReturnScatterOfAllSolidPoints(self):
         scatter = self.stats._get3DScatter()
-        self.assertEqual(scatter.shape, (4, 8))
-        self.assertTrue(np.array_equal(scatter[3], np.full(8, 0.1)))
+        self.assertEqual(scatter.shape, (8, 4))
+        self.assertTrue(np.array_equal(scatter[:, 3], np.full(8, 0.1)))
 
     def testWhenGet3DScatterOfSurface_shouldReturnScatterOfAllPointsLeavingTheSurface(self):
         frontScatter = self.stats._get3DScatter(solidLabel="cube", surfaceLabel="front")
         self.assertEqual(0, frontScatter.size)
 
         backScatter = self.stats._get3DScatter(solidLabel="cube", surfaceLabel="back")
-        self.assertEqual(backScatter.shape, (4, 1))
-        self.assertEqual(0.2, backScatter[3])
+        self.assertEqual(backScatter.shape, (1, 4))
+        self.assertEqual(0.2, backScatter[:, 3])
 
     def testWhenGet3DScatterOfPointsEnteringSurface_shouldReturnScatterOfAllPointsEnteringTheSurface(self):
         frontScatter = self.stats._get3DScatter(solidLabel="cube", surfaceLabel="front", enteringSurface=True)
-        self.assertEqual(frontScatter.shape, (4, 1))
-        self.assertEqual(1, frontScatter[3])
+        self.assertEqual(frontScatter.shape, (1, 4))
+        self.assertEqual(1, frontScatter[:, 3])
 
         backScatter = self.stats._get3DScatter(solidLabel="cube", surfaceLabel="back", enteringSurface=True)
         self.assertEqual(0, backScatter.size)
@@ -50,9 +50,9 @@ class TestStats(unittest.TestCase):
 
         backScatter = self.stats._get2DScatter(solidLabel="cube", surfaceLabel="back")
         x, z, value = backScatter
-        self.assertEqual([0.], x)
-        self.assertEqual([1.], z)
-        self.assertEqual([0.2], value)
+        self.assertEqual(0, x)
+        self.assertEqual(1, z)
+        self.assertEqual(0.2, value)
 
     def testWhenGet1DScatterAlongZ_shouldReturnScatterOfAllSolidPointsProjectedOnZAxis(self):
         z, value = self.stats._get1DScatter(along="z")

--- a/pytissueoptics/rayscattering/tissues/phantomTissue.py
+++ b/pytissueoptics/rayscattering/tissues/phantomTissue.py
@@ -7,9 +7,9 @@ class PhantomTissue(RayScatteringScene):
     """ Phantom tissue consisting of 3 layers with various optical properties. """
     TISSUE = []
 
-    def __init__(self):
+    def __init__(self, worldMaterial=ScatteringMaterial()):
         self._create()
-        super().__init__(self.TISSUE)
+        super().__init__(self.TISSUE, worldMaterial)
 
     def _create(self):
         n = [1.4, 1.7, 1.4]

--- a/pytissueoptics/rayscattering/tissues/rayScatteringScene.py
+++ b/pytissueoptics/rayscattering/tissues/rayScatteringScene.py
@@ -1,12 +1,13 @@
 from typing import List
 
+from pytissueoptics.rayscattering.materials import ScatteringMaterial
 from pytissueoptics.scene import MayaviViewer, Scene
 from pytissueoptics.scene.solids import Solid
 
 
 class RayScatteringScene(Scene):
-    def __init__(self, solids: List[Solid]):
-        super().__init__(solids)
+    def __init__(self, solids: List[Solid], worldMaterial=ScatteringMaterial()):
+        super().__init__(solids, worldMaterial=worldMaterial)
 
     def addToViewer(self, viewer: MayaviViewer):
         raise NotImplementedError

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -38,27 +38,27 @@ class Logger:
                 and key.surfaceLabel is not None]
 
     def logPoint(self, point: Vector, key: InteractionKey):
-        self._appendData(np.array([[point.x, point.y, point.z]]).T, DataType.POINT, key)
+        self._appendData(np.array([[point.x, point.y, point.z]]), DataType.POINT, key)
 
     def logDataPoint(self, value: float, position: Vector, key: InteractionKey):
-        self._appendData(np.array([[value, position.x, position.y, position.z]]).T, DataType.DATA_POINT, key)
+        self._appendData(np.array([[value, position.x, position.y, position.z]]), DataType.DATA_POINT, key)
 
     def logSegment(self, start: Vector, end: Vector, key: InteractionKey):
-        self._appendData(np.array([[start.x, start.y, start.z, end.x, end.y, end.z]]).T, DataType.SEGMENT, key)
+        self._appendData(np.array([[start.x, start.y, start.z, end.x, end.y, end.z]]), DataType.SEGMENT, key)
 
     def logPointArray(self, array: np.ndarray, key: InteractionKey):
-        """ 'array' must be of shape (3, n) where first axis is (x, y, z) """
-        assert array.shape[0] == 3 and array.ndim == 2, "Point array must be of shape (3, n)"
+        """ 'array' must be of shape (n, 3) where second axis is (x, y, z) """
+        assert array.shape[1] == 3 and array.ndim == 2, "Point array must be of shape (n, 3)"
         self._appendData(array, DataType.POINT, key)
 
     def logDataPointArray(self, array: np.ndarray, key: InteractionKey):
-        """ 'array' must be of shape (4, n) where first axis is (value, x, y, z) """
-        assert array.shape[0] == 4 and array.ndim == 2, "Data point array must be of shape (4, n)"
+        """ 'array' must be of shape (n, 4) where second axis is (value, x, y, z) """
+        assert array.shape[1] == 4 and array.ndim == 2, "Data point array must be of shape (n, 4)"
         self._appendData(array, DataType.DATA_POINT, key)
 
     def logSegmentArray(self, array: np.ndarray, key: InteractionKey):
-        """ 'array' must be of shape (6, n) where first axis is (x1, y1, z1, x2, y2, z2) """
-        assert array.shape[0] == 6 and array.ndim == 2, "Segment array must be of shape (6, n)"
+        """ 'array' must be of shape (n, 6) where second axis is (x1, y1, z1, x2, y2, z2) """
+        assert array.shape[1] == 6 and array.ndim == 2, "Segment array must be of shape (n, 6)"
         self._appendData(array, DataType.SEGMENT, key)
 
     def _appendData(self, dataArray: np.ndarray, dataType: DataType, key: InteractionKey):
@@ -67,7 +67,7 @@ class Logger:
         if previousData is None:
             setattr(self._data[key], dataType.value, dataArray)
         else:
-            setattr(self._data[key], dataType.value, np.concatenate((previousData, dataArray), axis=1))
+            setattr(self._data[key], dataType.value, np.concatenate((previousData, dataArray), axis=0))
 
     def _validateKey(self, key: InteractionKey):
         if key not in self._data:
@@ -95,7 +95,7 @@ class Logger:
                 data.append(points)
             if len(data) == 0:
                 return None
-            return np.concatenate(data, axis=1)
+            return np.concatenate(data, axis=0)
 
     def _assertKeyExists(self, key: InteractionKey):
         if key.solidLabel not in self.getSolidLabels():

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -89,7 +89,10 @@ class Logger:
         else:
             data = []
             for interactionData in self._data.values():
-                data.append(getattr(interactionData, dataType.value))
+                points = getattr(interactionData, dataType.value)
+                if points is None:
+                    continue
+                data.append(points)
             if len(data) == 0:
                 return None
             return np.concatenate(data, axis=1)

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -8,14 +8,18 @@ from pytissueoptics.scene.geometry import Polygon, BoundingBox
 
 
 class Scene:
-    def __init__(self, solids: List[Solid] = None, ignoreIntersections=False):
+    def __init__(self, solids: List[Solid] = None, ignoreIntersections=False,
+                 worldMaterial=None):
         self._solids = []
         self._ignoreIntersections = ignoreIntersections
         self._labelsOfHiddenSolids = []
+        self._worldMaterial = worldMaterial
         
         if solids:
             for solid in solids:
                 self.add(solid)
+
+        self.resetOutsideMaterial()
 
     def add(self, solid: Solid, position: Vector = None):
         if position:
@@ -28,6 +32,9 @@ class Scene:
     @property
     def solids(self):
         return self._solids
+
+    def getWorldEnvironment(self) -> Environment:
+        return Environment(self._worldMaterial)
 
     def _validatePosition(self, newSolid: Solid):
         """ Assert newSolid position is valid and make proper adjustments so that the
@@ -99,8 +106,8 @@ class Scene:
             bbox.extendTo(solid.getBoundingBox())
         return bbox
 
-    def setOutsideMaterial(self, material):
-        outsideEnvironment = Environment(material)
+    def resetOutsideMaterial(self):
+        outsideEnvironment = self.getWorldEnvironment()
         for solid in self._solids:
             if solid.getLabel() in self._labelsOfHiddenSolids:
                 continue
@@ -112,8 +119,7 @@ class Scene:
                 if solid.isStack():
                     return self._getEnvironmentOfStackAt(position, solid)
                 return solid.getEnvironment()
-        # return self._worldEnvironement
-        return None
+        return self.getWorldEnvironment()
 
     @staticmethod
     def _getEnvironmentOfStackAt(position: Vector, stack: Solid) -> Environment:

--- a/pytissueoptics/scene/tests/logger/testLogger.py
+++ b/pytissueoptics/scene/tests/logger/testLogger.py
@@ -26,15 +26,15 @@ class TestLogger(unittest.TestCase):
 
         logger.logPoint(newPoint, self.INTERACTION_KEY)
 
-        self.assertEqual(3, logger.getPoints().shape[1])
-        self.assertTrue(np.array_equal([2, 0, 0], logger.getPoints()[:, -1]))
+        self.assertEqual(3, len(logger.getPoints()))
+        self.assertTrue(np.array_equal([2, 0, 0], logger.getPoints()[-1]))
 
     def testWhenLogPointArray_shouldAddAllPointsToTheLoggedPoints(self):
         logger = Logger()
-        logger.logPointArray(np.array([[0, 0, 0], [1, 0, 0]]).T, self.INTERACTION_KEY)
+        logger.logPointArray(np.array([[0, 0, 0], [1, 0, 0]]), self.INTERACTION_KEY)
 
-        self.assertEqual(2, logger.getPoints().shape[1])
-        self.assertTrue(np.array_equal([1, 0, 0], logger.getPoints()[:, -1]))
+        self.assertEqual(2, len(logger.getPoints()))
+        self.assertTrue(np.array_equal([1, 0, 0], logger.getPoints()[-1]))
 
     def testWhenLogNewDataPoint_shouldAddDataPointToTheLoggedDataPoints(self):
         logger = Logger()
@@ -43,15 +43,15 @@ class TestLogger(unittest.TestCase):
 
         logger.logDataPoint(10, Vector(2, 0, 0), self.INTERACTION_KEY)
 
-        self.assertEqual(3, logger.getDataPoints().shape[1])
-        self.assertTrue(np.array_equal([10, 2, 0, 0], logger.getDataPoints()[:, -1]))
+        self.assertEqual(3, len(logger.getDataPoints()))
+        self.assertTrue(np.array_equal([10, 2, 0, 0], logger.getDataPoints()[-1]))
 
     def testWhenLogDataPointArray_shouldAddAllDataPointsToTheLoggedDataPoints(self):
         logger = Logger()
-        logger.logDataPointArray(np.array([[2, 0, 0, 0], [1, 1, 0, 0]]).T, self.INTERACTION_KEY)
+        logger.logDataPointArray(np.array([[2, 0, 0, 0], [1, 1, 0, 0]]), self.INTERACTION_KEY)
 
-        self.assertEqual(2, logger.getDataPoints().shape[1])
-        self.assertTrue(np.array_equal([1, 1, 0, 0], logger.getDataPoints()[:, -1]))
+        self.assertEqual(2, len(logger.getDataPoints()))
+        self.assertTrue(np.array_equal([1, 1, 0, 0], logger.getDataPoints()[-1]))
 
     def testWhenLogNewSegment_shouldAddSegmentToTheLoggedSegments(self):
         logger = Logger()
@@ -60,15 +60,15 @@ class TestLogger(unittest.TestCase):
 
         logger.logSegment(Vector(0, 0, 0), Vector(1, 0, 0), self.INTERACTION_KEY)
 
-        self.assertEqual(3, logger.getSegments().shape[1])
-        self.assertTrue(np.array_equal([0, 0, 0, 1, 0, 0], logger.getSegments()[:, -1]))
+        self.assertEqual(3, len(logger.getSegments()))
+        self.assertTrue(np.array_equal([0, 0, 0, 1, 0, 0], logger.getSegments()[-1]))
 
     def testWhenLogSegmentArray_shouldAddAllSegmentsToTheLoggedSegments(self):
         logger = Logger()
-        logger.logSegmentArray(np.array([[0, 0, 0, 1, 1, 1], [1, 1, 1, 2, 2, 2]]).T, self.INTERACTION_KEY)
+        logger.logSegmentArray(np.array([[0, 0, 0, 1, 1, 1], [1, 1, 1, 2, 2, 2]]), self.INTERACTION_KEY)
 
-        self.assertEqual(2, logger.getSegments().shape[1])
-        self.assertTrue(np.array_equal([1, 1, 1, 2, 2, 2], logger.getSegments()[:, -1]))
+        self.assertEqual(2, len(logger.getSegments()))
+        self.assertTrue(np.array_equal([1, 1, 1, 2, 2, 2], logger.getSegments()[-1]))
 
     def testWhenGetDataWithKey_shouldReturnDataStoredForThisKey(self):
         sameKey = InteractionKey(self.SOLID_LABEL, self.SURFACE_LABEL)
@@ -81,8 +81,8 @@ class TestLogger(unittest.TestCase):
         logger.logPoint(Vector(2, 0, 0), anotherKey)
         logger.logPoint(Vector(3, 0, 0), anotherKeyWithoutSurface)
 
-        self.assertEqual(2, logger.getPoints(self.INTERACTION_KEY).shape[1])
-        self.assertEqual(1, logger.getPoints(anotherKeyWithoutSurface).shape[1])
+        self.assertEqual(2, len(logger.getPoints(self.INTERACTION_KEY)))
+        self.assertEqual(1, len(logger.getPoints(anotherKeyWithoutSurface)))
 
     def testWhenGetDataWithEmptyKey_shouldReturnAllData(self):
         anotherKey = InteractionKey(self.SOLID_LABEL, "another surface")
@@ -91,8 +91,8 @@ class TestLogger(unittest.TestCase):
         logger.logPoint(Vector(1, 0, 0), self.INTERACTION_KEY)
         logger.logPoint(Vector(2, 0, 0), anotherKey)
 
-        self.assertEqual(3, logger.getPoints().shape[1])
-        self.assertEqual(3, logger.getPoints(InteractionKey(None, None)).shape[1])
+        self.assertEqual(3, len(logger.getPoints()))
+        self.assertEqual(3, len(logger.getPoints(InteractionKey(None, None))))
 
     def testWhenGetDataWithNonExistentKey_shouldRaiseKeyError(self):
         logger = Logger()

--- a/pytissueoptics/scene/tests/logger/testLogger.py
+++ b/pytissueoptics/scene/tests/logger/testLogger.py
@@ -105,6 +105,13 @@ class TestLogger(unittest.TestCase):
 
         self.assertRaises(KeyError, logger.getPoints, InteractionKey(self.SOLID_LABEL, "another surface"))
 
+    def testGivenEmptyLogger_whenGetData_shouldReturnNone(self):
+        logger = Logger()
+
+        self.assertIsNone(logger.getPoints())
+        self.assertIsNone(logger.getSegments())
+        self.assertIsNone(logger.getDataPoints())
+
     def testWhenGetSolidLabels_shouldReturnAListOfUniqueSolidLabels(self):
         solidLabel1 = "A label"
         solidLabel2 = "Another label"

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -42,32 +42,32 @@ class MayaviViewer:
 
     @staticmethod
     def addPoints(points: np.ndarray, colormap="rainbow", reverseColormap=False, scale=0.01):
-        """ 'points' has to be of shape (3, n) where the first axis is (x, y, z). """
+        """ 'points' has to be of shape (n, 3) where the second axis is (x, y, z). """
         if points is None:
             return
-        x, y, z = points
+        x, y, z = [points[:, i] for i in range(3)]
         s = mlab.points3d(x, y, z, mode="sphere", scale_factor=scale, scale_mode="none", colormap=colormap)
         s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
 
     @staticmethod
     def addDataPoints(dataPoints: np.ndarray, colormap="rainbow", reverseColormap=False, scale=0.15, scaleWithValue=True):
-        """ 'dataPoints' has to be of shape (4, n) where the first axis is (value, x, y, z). """
+        """ 'dataPoints' has to be of shape (n, 4) where the second axis is (value, x, y, z). """
         if dataPoints is None:
             return
-        v, x, y, z = dataPoints
+        v, x, y, z = [dataPoints[:, i] for i in range(4)]
         scaleMode = "scalar" if scaleWithValue else "none"
         s = mlab.points3d(x, y, z, v, mode="sphere", scale_factor=scale, scale_mode=scaleMode, colormap=colormap)
         s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
 
     @staticmethod
     def addSegments(segments: np.ndarray, colormap="rainbow", reverseColormap=False):
-        """ 'segments' has to be of shape (6, n) where the first axis is (x1, y1, z1, x2, y2, z2). """
+        """ 'segments' has to be of shape (n, 6) where the second axis is (x1, y1, z1, x2, y2, z2). """
         if segments is None:
             return
-        for i in range(segments.shape[1]):
-            x = [segments[0, i], segments[3, i]]
-            y = [segments[1, i], segments[4, i]]
-            z = [segments[2, i], segments[5, i]]
+        for segment in segments:
+            x = [segment[0], segment[3]]
+            y = [segment[1], segment[4]]
+            z = [segment[2], segment[5]]
             s = mlab.plot3d(x, y, z, tube_radius=None, line_width=1, colormap=colormap)
             s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
 

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -43,6 +43,8 @@ class MayaviViewer:
     @staticmethod
     def addPoints(points: np.ndarray, colormap="rainbow", reverseColormap=False, scale=0.01):
         """ 'points' has to be of shape (3, n) where the first axis is (x, y, z). """
+        if points is None:
+            return
         x, y, z = points
         s = mlab.points3d(x, y, z, mode="sphere", scale_factor=scale, scale_mode="none", colormap=colormap)
         s.module_manager.scalar_lut_manager.reverse_lut = reverseColormap
@@ -50,6 +52,8 @@ class MayaviViewer:
     @staticmethod
     def addDataPoints(dataPoints: np.ndarray, colormap="rainbow", reverseColormap=False, scale=0.15, scaleWithValue=True):
         """ 'dataPoints' has to be of shape (4, n) where the first axis is (value, x, y, z). """
+        if dataPoints is None:
+            return
         v, x, y, z = dataPoints
         scaleMode = "scalar" if scaleWithValue else "none"
         s = mlab.points3d(x, y, z, v, mode="sphere", scale_factor=scale, scale_mode=scaleMode, colormap=colormap)
@@ -58,6 +62,8 @@ class MayaviViewer:
     @staticmethod
     def addSegments(segments: np.ndarray, colormap="rainbow", reverseColormap=False):
         """ 'segments' has to be of shape (6, n) where the first axis is (x1, y1, z1, x2, y2, z2). """
+        if segments is None:
+            return
         for i in range(segments.shape[1]):
             x = [segments[0, i], segments[3, i]]
             y = [segments[1, i], segments[4, i]]


### PR DESCRIPTION
## Changes
- You can now set a world material when creating a Scene (instead of later during propagation)
- Source can be positioned anywhere in the scene. Photon context will be automatically initialized with the correct environment. 
- Added simple source graphic (shere) showed by default on Stats 3D displays

## Implementation details
- Moved world material context out of source.propagate and into Scene
- Source environment is determined when starting propagation by asking the scene what is the environment at the source position (uses a special algo when dealing with stacks). 
- Stats now adds the source photonCount to a solid's total input energy when the source is contained in it. 

## Example
Showing a few graphs from `rayscattering/example.py` with source positioned at `Vector(0, 0, 0.3)`. 
![snap_3d_source](https://user-images.githubusercontent.com/29587649/165638073-ffa3fe21-c5f4-4ec2-be47-d187cb227291.png)

![snap_3dsurfaces_source](https://user-images.githubusercontent.com/29587649/165638104-a293e5ad-edae-463e-8650-9122aac5d5fd.png)
![snap_1d_source](https://user-images.githubusercontent.com/29587649/165638117-677fcf9d-bcc5-412f-9fb7-b393d07f93c7.png)

```
Report of solid 'frontLayer'
  Absorbance: 42.4% (43.2% of total power)
  Absorbance + Transmittance: 100.0%
    Transmittance at 'interface1': 56.1%
    Transmittance at 'front': 0.9%
    Transmittance at 'top': 0.2%
    Transmittance at 'left': 0.2%
    Transmittance at 'bottom': 0.1%
    Transmittance at 'right': 0.2%
Report of solid 'middleLayer'
  Absorbance: 51.8% (30.2% of total power)
  Absorbance + Transmittance: 100.0%
    Transmittance at 'interface1': 3.2%
    Transmittance at 'bottom': 0.3%
    Transmittance at 'interface0': 44.0%
    Transmittance at 'right': 0.3%
    Transmittance at 'left': 0.2%
    Transmittance at 'top': 0.2%
Report of solid 'backLayer'
  Absorbance: 67.9% (17.4% of total power)
  Absorbance + Transmittance: 100.0%
    Transmittance at 'interface0': 4.9%
    Transmittance at 'back': 23.2%
    Transmittance at 'top': 0.8%
    Transmittance at 'right': 0.9%
    Transmittance at 'bottom': 1.2%
    Transmittance at 'left': 1.2%
```