### PR TITLE
Save and load logger

### DIFF
--- a/pytissueoptics/rayscattering/source.py
+++ b/pytissueoptics/rayscattering/source.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import List, Optional
 
 from pytissueoptics.rayscattering.tissues.rayScatteringScene import RayScatteringScene
 from pytissueoptics.rayscattering.photon import Photon
@@ -21,10 +21,18 @@ class Source:
     def propagate(self, scene: RayScatteringScene, logger: Logger = None):
         intersectionFinder = SimpleIntersectionFinder(scene)
         self._environment = scene.getEnvironmentAt(self._position)
+        self._prepareLogger(logger)
 
         for photon in self._photons:
             photon.setContext(self._environment, intersectionFinder=intersectionFinder, logger=logger)
             photon.propagate()
+
+    def _prepareLogger(self, logger: Optional[Logger]):
+        if logger is None:
+            return
+        if "photonCount" not in logger.info:
+            logger.info["photonCount"] = 0
+        logger.info["photonCount"] += self.getPhotonCount()
 
     @property
     def photons(self):

--- a/pytissueoptics/rayscattering/stats.py
+++ b/pytissueoptics/rayscattering/stats.py
@@ -60,7 +60,6 @@ class Stats:
 
         solidSource = source.getEnvironment().solid
         self._sourceSolidLabel = solidSource.getLabel() if solidSource else None
-        self._photonCount = source.getPhotonCount()
         self._source = source
 
     def showEnergy3D(self, solidLabel: str = None, surfaceLabel: str = None, config=DisplayConfig()):
@@ -74,6 +73,11 @@ class Stats:
     def showEnergy3DOfSurfaces(self, solidLabel: str = None, config=DisplayConfig()):
         pointCloud = self._getPointCloudOfSurfaces(solidLabel)
         return self._show3DPointCloud(pointCloud, config=config)
+
+    def getPhotonCount(self) -> int:
+        if "photonCount" not in self._logger.info:
+            return self._source.getPhotonCount()
+        return self._logger.info["photonCount"]
 
     def _show3DPointCloud(self, pointCloud: PointCloud, config: DisplayConfig):
         from pytissueoptics.scene import MayaviViewer
@@ -190,17 +194,17 @@ class Stats:
     def getAbsorbance(self, solidLabel: str = None, useTotalEnergy=False) -> float:
         points = self.getPointCloud(solidLabel).solidPoints
         energy = np.sum(points[:, 0])
-        energyInput = self._getEnergyInput(solidLabel) if not useTotalEnergy else self._photonCount
+        energyInput = self._getEnergyInput(solidLabel) if not useTotalEnergy else self.getPhotonCount()
         return energy / energyInput
 
     def _getEnergyInput(self, solidLabel: str = None) -> float:
         if solidLabel is None:
-            return self._photonCount
+            return self.getPhotonCount()
         points = self._getPointCloudOfSurfaces(solidLabel).enteringSurfacePoints
         energy = -np.sum(points[:, 0]) if points is not None else 0
 
         if self._sourceSolidLabel == solidLabel:
-            energy += self._photonCount
+            energy += self.getPhotonCount()
         return energy
 
     def getTransmittance(self, solidLabel: str = None, surfaceLabel: str = None, useTotalEnergy=False):
@@ -212,7 +216,7 @@ class Stats:
             points = self.getPointCloud(solidLabel, surfaceLabel).leavingSurfacePoints
 
         energy = np.sum(points[:, 0])
-        energyInput = self._getEnergyInput(solidLabel) if not useTotalEnergy else self._photonCount
+        energyInput = self._getEnergyInput(solidLabel) if not useTotalEnergy else self.getPhotonCount()
         return energy / energyInput
 
     def report(self, solidLabel: str = None):

--- a/pytissueoptics/rayscattering/tests/testSource.py
+++ b/pytissueoptics/rayscattering/tests/testSource.py
@@ -6,6 +6,7 @@ from pytissueoptics.rayscattering import PencilSource, Photon
 from pytissueoptics.rayscattering.materials import ScatteringMaterial
 from pytissueoptics.rayscattering.source import Source
 from pytissueoptics.rayscattering.tissues.rayScatteringScene import RayScatteringScene
+from pytissueoptics.scene import Logger
 from pytissueoptics.scene.geometry import Environment, Vector
 
 
@@ -20,6 +21,15 @@ class TestSource(unittest.TestCase):
     def testWhenPropagate_shouldSetInitialPhotonEnvironmentAsSourceEnvironment(self):
         self.source.propagate(self._createTissue())
         verify(self.photon).setContext(self.SOURCE_ENV, ...)
+
+    def testWhenPropagate_shouldUpdatePhotonCountInLogger(self):
+        logger = Logger()
+        self.source.propagate(self._createTissue(), logger=logger)
+        self.assertEqual(logger.info['photonCount'], 1)
+
+        logger.info['photonCount'] = 10
+        self.source.propagate(self._createTissue(), logger=logger)
+        self.assertEqual(logger.info['photonCount'], 10+1)
 
     def testWhenPropagate_shouldPropagateAllPhotons(self):
         self.source.propagate(self._createTissue())

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -1,3 +1,4 @@
+import pickle
 from dataclasses import dataclass
 from typing import List, Dict, Optional
 from enum import Enum
@@ -29,6 +30,7 @@ class DataType(Enum):
 class Logger:
     def __init__(self):
         self._data: Dict[InteractionKey, InteractionData] = {}
+        self.info: dict = {}
 
     def getSolidLabels(self) -> List[str]:
         return list(set(key.solidLabel for key in self._data.keys()))
@@ -103,3 +105,11 @@ class Logger:
         if key.surfaceLabel and key.surfaceLabel not in self.getSurfaceLabels(key.solidLabel):
             raise KeyError(f"Invalid surface label '{key.surfaceLabel}' for solid '{key.solidLabel}'. "
                            f"Available: {self.getSurfaceLabels(key.solidLabel)}. ")
+
+    def save(self, filepath: str):
+        with open(filepath, "wb") as file:
+            pickle.dump((self._data, self.info), file)
+
+    def load(self, filepath: str):
+        with open(filepath, "rb") as file:
+            self._data, self.info = pickle.load(file)

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -113,3 +113,9 @@ class Logger:
     def load(self, filepath: str):
         with open(filepath, "rb") as file:
             self._data, self.info = pickle.load(file)
+
+    @classmethod
+    def fromFile(cls, filepath: str) -> 'Logger':
+        logger = Logger()
+        logger.load(filepath)
+        return logger

--- a/pytissueoptics/scene/tests/logger/testLogger.py
+++ b/pytissueoptics/scene/tests/logger/testLogger.py
@@ -194,7 +194,7 @@ class TestLogger(unittest.TestCase):
             filePath = os.path.join(tempDir, "test.log")
             previousLogger.save(filePath)
 
-            logger = Logger.fromFile(filePath)
+            logger = Logger(filePath)
 
             self.assertTrue(np.array_equal(previousLogger.getPoints(), logger.getPoints()))
             self.assertEqual(previousLogger.info, logger.info)

--- a/pytissueoptics/scene/tests/logger/testLogger.py
+++ b/pytissueoptics/scene/tests/logger/testLogger.py
@@ -1,4 +1,6 @@
+import os
 import unittest
+import tempfile
 
 import numpy as np
 
@@ -154,3 +156,29 @@ class TestLogger(unittest.TestCase):
         self.assertEqual(2, len(surfaceLabels))
         self.assertTrue(surfaceA in surfaceLabels)
         self.assertTrue(surfaceB in surfaceLabels)
+
+    def testWhenSave_shouldSaveLoggerToFile(self):
+        logger = Logger()
+
+        with tempfile.TemporaryDirectory() as tempDir:
+            filePath = os.path.join(tempDir, "test.log")
+            logger.save(filePath)
+
+            self.assertTrue(os.path.exists(filePath))
+
+    def testGivenALoggerPreviouslySaved_whenLoad_shouldLoadPreviousLoggerFromFile(self):
+        previousLogger = Logger()
+        previousLogger.logPoint(Vector(0, 0, 0), self.INTERACTION_KEY)
+        previousLogger.logPoint(Vector(1, 0, 0), self.INTERACTION_KEY)
+        previousLogger.logPoint(Vector(2, 0, 0), self.INTERACTION_KEY)
+        previousLogger.info["some key"] = "some metadata"
+
+        with tempfile.TemporaryDirectory() as tempDir:
+            filePath = os.path.join(tempDir, "test.log")
+            previousLogger.save(filePath)
+
+            logger = Logger()
+            logger.load(filePath)
+
+            self.assertTrue(np.array_equal(previousLogger.getPoints(), logger.getPoints()))
+            self.assertEqual(previousLogger.info, logger.info)

--- a/pytissueoptics/scene/tests/logger/testLogger.py
+++ b/pytissueoptics/scene/tests/logger/testLogger.py
@@ -182,3 +182,19 @@ class TestLogger(unittest.TestCase):
 
             self.assertTrue(np.array_equal(previousLogger.getPoints(), logger.getPoints()))
             self.assertEqual(previousLogger.info, logger.info)
+
+    def testGivenALoggerPreviouslySaved_whenCreatingNewLoggerFromFile_shouldLoadPreviousLoggerFromFile(self):
+        previousLogger = Logger()
+        previousLogger.logPoint(Vector(0, 0, 0), self.INTERACTION_KEY)
+        previousLogger.logPoint(Vector(1, 0, 0), self.INTERACTION_KEY)
+        previousLogger.logPoint(Vector(2, 0, 0), self.INTERACTION_KEY)
+        previousLogger.info["some key"] = "some metadata"
+
+        with tempfile.TemporaryDirectory() as tempDir:
+            filePath = os.path.join(tempDir, "test.log")
+            previousLogger.save(filePath)
+
+            logger = Logger.fromFile(filePath)
+
+            self.assertTrue(np.array_equal(previousLogger.getPoints(), logger.getPoints()))
+            self.assertEqual(previousLogger.info, logger.info)


### PR DESCRIPTION
### Changes
- Added save and load methods as well as fromFilepath init argument to Logger.
- Added logger.info dictionary to store any metadata. This is used in the rayscattering module to store photon count. 
- Source.propagate now updates logger.info['photonCount']. This allows Stats to have the correct total energy input. 

Usage example to save a logger:
```python 
... 
logger = Logger()

source.propagate(tissue, logger=logger)

logger.save("simulation.log")
...
```

Usage example to extend an existing logger: 
```python 
... 
logger = Logger("simulation.log")

source.propagate(tissue, logger=logger)

logger.save()

stats = Stats(logger, source, tissue)
stats.report()
...
```
