### PR TITLE
Solid: new scale method

### DIFF
--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -82,6 +82,15 @@ class Solid:
         self._resetBoundingBoxes()
         self._resetPolygonsCentroids()
 
+    def scale(self, factor: float):
+        for v in self._vertices:
+            v.multiply(factor)
+
+        previousPosition = self._position.copy()
+        self._position = self._position * factor
+        positionDifference = previousPosition - self._position
+        self.translateBy(positionDifference)
+
     def rotate(self, xTheta=0, yTheta=0, zTheta=0):
         """
         Requires the angle in degrees for each axis around which the solid will be rotated.

--- a/pytissueoptics/scene/tests/solids/testSolid.py
+++ b/pytissueoptics/scene/tests/solids/testSolid.py
@@ -91,6 +91,15 @@ class TestSolid(unittest.TestCase):
         verify(polygon, times=3).resetBoundingBox()
         self.assertNotEqual(oldBbox, solid.bbox)
 
+    def testWhenScale_shouldScaleAllVerticesFromTheCenter(self):
+        self.solid.translateTo(Vector(5, 5, 5))
+
+        self.solid.scale(5)
+
+        self.assertEqual(Vector(5, 5, 5), self.solid.position)
+        self.assertEqual(Vector(0, 0, 0), self.solid.vertices[0])
+        self.assertEqual(Vector(10, 10, 10), self.solid.vertices[6])
+
     def testWhenTranslate_shouldTranslateBBoxOfSolidAndPolygons(self):
         polygon = self.createPolygonMock()
         self.CUBOID_SURFACES.setPolygons('front', [polygon])


### PR DESCRIPTION
Added method `scale(factor: float)` to `Solid`.

![image](https://user-images.githubusercontent.com/29587649/167164224-f9642f57-0e59-4a71-847d-9954d756abfb.png)

```python 
ellipsoid.scale(0.5)
cuboid.scale(1.2)
sphere.scale(0.6)
```
![image](https://user-images.githubusercontent.com/29587649/167164110-781b70cd-20da-4cc3-a5d5-afbd1253c20b.png)
