### PR TITLE
list logging for performance + auto report save

### DIFF
--- a/pytissueoptics/rayscattering/opencl/CLPhotons.py
+++ b/pytissueoptics/rayscattering/opencl/CLPhotons.py
@@ -109,7 +109,7 @@ class CLPhotons:
         self._HOST_material["mu_a"] = np.float32(self._worldMaterial.mu_a)
         self._HOST_material["mu_t"] = np.float32(self._worldMaterial.mu_t)
         self._HOST_material["g"] = np.float32(self._worldMaterial.g)
-        self._HOST_material["n"] = np.float32(self._worldMaterial.index)
+        self._HOST_material["n"] = np.float32(self._worldMaterial.n)
         self._HOST_material["albedo"] = np.float32(self._worldMaterial.getAlbedo())
         self._HOST_material["material_id"] = np.uint32(0)
         self._DEVICE_material = cl.Buffer(self._context, cl.mem_flags.READ_ONLY | cl.mem_flags.COPY_HOST_PTR,

--- a/pytissueoptics/rayscattering/stats.py
+++ b/pytissueoptics/rayscattering/stats.py
@@ -33,9 +33,11 @@ class PointCloud:
 
 class DisplayConfig:
     """ 3D display configuration dataclass for solid and surface point cloud. """
-    def __init__(self, showScene: bool = True, showSource: bool = True, sourceSize: float = 0.1, showPointsAsSpheres: bool = True,
-                 pointSize: float = 0.15, scaleWithValue: bool = True, colormap: str = "rainbow", reverseColormap: bool = False,
-                 surfacePointSize: float = 0.01, surfaceScaleWithValue: bool = False, surfaceColormap: str = None, surfaceReverseColormap: bool = None):
+
+    def __init__(self, showScene: bool = True, showSource: bool = True, sourceSize: float = 0.1,
+                 showPointsAsSpheres: bool = True, pointSize: float = 0.15, scaleWithValue: bool = True,
+                 colormap: str = "rainbow", reverseColormap: bool = False, surfacePointSize: float = 0.01,
+                 surfaceScaleWithValue: bool = False, surfaceColormap: str = None, surfaceReverseColormap: bool = None):
         self.showScene = showScene
         self.showSource = showSource
         self.sourceSize = sourceSize
@@ -139,7 +141,8 @@ class Stats:
 
     def showEnergy2D(self, solidLabel: str = None, surfaceLabel: str = None,
                      projection: Union[str, Vector] = 'y', bins: Union[int, Tuple[int, int]] = None,
-                     limits: List[List[float]] = None, logScale: bool = False, enteringSurface=False, colormap: str = 'viridis'):
+                     limits: List[List[float]] = None, logScale: bool = False, enteringSurface=False,
+                     colormap: str = 'viridis'):
         u, v, c = self._get2DScatter(solidLabel, surfaceLabel, projection, enteringSurface)
 
         norm = matplotlib.colors.LogNorm() if logScale else None
@@ -233,26 +236,47 @@ class Stats:
     def _sumEnergy(points: np.ndarray):
         return np.abs(np.sum(points[:, 0])) if points is not None else 0
 
-    def report(self, solidLabel: str = None):
+    def _makeReport(self, solidLabel: str = None, reportString: str = ""):
         if solidLabel:
-            return self._reportSolid(solidLabel)
-        for solidLabel in self._logger.getSolidLabels():
-            self.report(solidLabel)
+            reportString += self._reportSolid(solidLabel)
+        else:
+            for solidLabel in self._logger.getSolidLabels():
+                reportString = self._makeReport(solidLabel, reportString)
+        return reportString
+
+    def report(self, solidLabel: str = None, save=True, filepath=None):
+        reportString = self._makeReport(solidLabel=solidLabel)
+        if save:
+            self.saveReport(reportString, filepath)
+        print(reportString)
 
     def _reportSolid(self, solidLabel: str):
-        print("Report of solid '{}'".format(solidLabel))
+        reportString = "Report of solid '{}'\n".format(solidLabel)
         try:
-            print("  Absorbance: {:.1f}% ({:.1f}% of total power)".format(100 * self.getAbsorbance(solidLabel),
-                  100 * self.getAbsorbance(solidLabel, useTotalEnergy=True)))
-            print("  Absorbance + Transmittance: {:.1f}%".format(100 * (self.getAbsorbance(solidLabel) +
-                                                                        self.getTransmittance(solidLabel))))
+            reportString += (
+                "  Absorbance: {:.1f}% ({:.1f}% of total power)\n".format(100 * self.getAbsorbance(solidLabel),
+                                                                          100 * self.getAbsorbance(solidLabel,
+                                                                                                   useTotalEnergy=True)))
+            reportString += ("  Absorbance + Transmittance: {:.1f}%\n".format(100 * (self.getAbsorbance(solidLabel) +
+                                                                                     self.getTransmittance(
+                                                                                         solidLabel))))
 
             for surfaceLabel in self._logger.getSurfaceLabels(solidLabel):
                 transmittance = "{0:.1f}".format(100 * self.getTransmittance(solidLabel, surfaceLabel))
-                print(f"    Transmittance at '{surfaceLabel}': {transmittance}%")
+                reportString += f"    Transmittance at '{surfaceLabel}': {transmittance}%\n"
 
         except ZeroDivisionError:
             warnings.warn("No energy input for solid '{}'".format(solidLabel))
-            print("  Absorbance: N/A ({:.1f}% of total power)".format(100 * self.getAbsorbance(solidLabel,
-                                                                                               useTotalEnergy=True)))
-            print("  Absorbance + Transmittance: N/A")
+            reportString += ("  Absorbance: N/A ({:.1f}% of total power)\n".format(100 * self.getAbsorbance(solidLabel,
+                                                                                                            useTotalEnergy=True)))
+            reportString += "  Absorbance + Transmittance: N/A\n"
+        return reportString
+
+    @staticmethod
+    def saveReport(report: str, filepath: str = None):
+        if filepath is None:
+            filepath = "simulation.results"
+            warnings.warn(f"No filepath specified. Saving to {filepath}.")
+        with open(filepath, "wb") as file:
+            file.write(report.encode("utf-8"))
+            file.close()

--- a/pytissueoptics/scene/logger/logger.py
+++ b/pytissueoptics/scene/logger/logger.py
@@ -2,7 +2,7 @@ import os
 import pickle
 import warnings
 from dataclasses import dataclass
-from typing import List, Dict, Optional
+from typing import List, Dict, Optional, Union
 from enum import Enum
 
 import numpy as np
@@ -18,9 +18,9 @@ class InteractionKey:
 
 @dataclass
 class InteractionData:
-    points: np.ndarray = None
-    dataPoints: np.ndarray = None
-    segments: np.ndarray = None
+    points: [] = None
+    dataPoints: [] = None
+    segments: [] = None
 
 
 class DataType(Enum):
@@ -46,13 +46,13 @@ class Logger:
                 and key.surfaceLabel is not None]
 
     def logPoint(self, point: Vector, key: InteractionKey):
-        self._appendData(np.array([[point.x, point.y, point.z]]), DataType.POINT, key)
+        self._appendData([point.x, point.y, point.z], DataType.POINT, key)
 
     def logDataPoint(self, value: float, position: Vector, key: InteractionKey):
-        self._appendData(np.array([[value, position.x, position.y, position.z]]), DataType.DATA_POINT, key)
+        self._appendData([value, position.x, position.y, position.z], DataType.DATA_POINT, key)
 
     def logSegment(self, start: Vector, end: Vector, key: InteractionKey):
-        self._appendData(np.array([[start.x, start.y, start.z, end.x, end.y, end.z]]), DataType.SEGMENT, key)
+        self._appendData([start.x, start.y, start.z, end.x, end.y, end.z], DataType.SEGMENT, key)
 
     def logPointArray(self, array: np.ndarray, key: InteractionKey):
         """ 'array' must be of shape (n, 3) where second axis is (x, y, z) """
@@ -69,13 +69,19 @@ class Logger:
         assert array.shape[1] == 6 and array.ndim == 2, "Segment array must be of shape (n, 6)"
         self._appendData(array, DataType.SEGMENT, key)
 
-    def _appendData(self, dataArray: np.ndarray, dataType: DataType, key: InteractionKey):
+    def _appendData(self, data: Union[List, np.ndarray], dataType: DataType, key: InteractionKey):
         self._validateKey(key)
         previousData = getattr(self._data[key], dataType.value)
         if previousData is None:
-            setattr(self._data[key], dataType.value, dataArray)
+            if type(data) == list:
+                setattr(self._data[key], dataType.value, [data])
+            elif type(data) == np.ndarray:
+                setattr(self._data[key], dataType.value, data.tolist())
         else:
-            setattr(self._data[key], dataType.value, np.concatenate((previousData, dataArray), axis=0))
+            if type(data) == list:
+                previousData.append(data)
+            elif type(data) == np.ndarray:
+                previousData.extend(data.tolist())
 
     def _validateKey(self, key: InteractionKey):
         if key not in self._data:
@@ -94,17 +100,17 @@ class Logger:
         if key and key.solidLabel:
             if not self._keyExists(key):
                 return None
-            return getattr(self._data[key], dataType.value)
+            return np.array(getattr(self._data[key], dataType.value))
         else:
             data = []
             for interactionData in self._data.values():
                 points = getattr(interactionData, dataType.value)
                 if points is None:
                     continue
-                data.append(points)
+                data.extend(points)
             if len(data) == 0:
                 return None
-            return np.concatenate(data, axis=0)
+            return np.array(data)
 
     def _keyExists(self, key: InteractionKey) -> bool:
         if key.solidLabel not in self.getSolidLabels():

--- a/pytissueoptics/scene/tests/logger/testLogger.py
+++ b/pytissueoptics/scene/tests/logger/testLogger.py
@@ -92,9 +92,11 @@ class TestLogger(unittest.TestCase):
         logger.logPoint(Vector(0, 0, 0), self.INTERACTION_KEY)
         logger.logPoint(Vector(1, 0, 0), self.INTERACTION_KEY)
         logger.logPoint(Vector(2, 0, 0), anotherKey)
+        logger.logPoint(Vector(3, 0, 0), anotherKey)
 
-        self.assertEqual(3, len(logger.getPoints()))
-        self.assertEqual(3, len(logger.getPoints(InteractionKey(None, None))))
+        print(logger.getPoints())
+        self.assertEqual(4, len(logger.getPoints()))
+        self.assertEqual(4, len(logger.getPoints(InteractionKey(None, None))))
 
     def testWhenGetDataWithNonExistentKey_shouldWarnAndReturnNone(self):
         logger = Logger()


### PR DESCRIPTION
- logging is done by `append` on a list rather than `np.concatenate` which was O(N) and caused massive slowdown during the simulation. `append is amortized O(1), which yield much faster simulations.

- to manage the array logging, I added a typecheck when `_appendData` and convert the array to a list with `np.tolist()`

- added an autosave on the `Stats.report` method 