### PR TITLE
Reduce RAM usage

### DIFF
--- a/pytissueoptics/rayscattering/opencl/CLKeyLog.py
+++ b/pytissueoptics/rayscattering/opencl/CLKeyLog.py
@@ -33,9 +33,9 @@ class CLKeyLog:
 
     def _extractNoKeyLog(self):
         noInteractionIndices = np.where(self._log[:, SOLID_ID_COL] == NO_LOG_ID)[0]
-        datapoints = self._log[:, :4]
-        datapoints = np.delete(datapoints, noInteractionIndices, axis=0)
-        self._keyLog[InteractionKey(NO_SOLID_LABEL, None)] = datapoints
+        self._log = self._log[:, :4]
+        self._log = np.delete(self._log, noInteractionIndices, axis=0)
+        self._keyLog[InteractionKey(NO_SOLID_LABEL, None)] = self._log
 
     def _sortLocal(self):
         """ Sorts the log locally by solidID and surfaceID,

--- a/pytissueoptics/rayscattering/opencl/CLParameters.py
+++ b/pytissueoptics/rayscattering/opencl/CLParameters.py
@@ -65,3 +65,10 @@ class CLParameters:
     @photonsPerWorkItem.setter
     def photonsPerWorkItem(self, value: int):
         self._maxPhotonsPerBatch = np.int32(value * self._workItemAmount)
+
+    @property
+    def requiredRAMBytes(self) -> float:
+        concatenationFactor = 2
+        averageNBatches = int(1.3 * (1 / CONFIG.BATCH_LOAD_FACTOR))
+        overHead = 1.15
+        return overHead * concatenationFactor * averageNBatches * self._maxLoggerMemory

--- a/pytissueoptics/rayscattering/opencl/CLParameters.py
+++ b/pytissueoptics/rayscattering/opencl/CLParameters.py
@@ -1,3 +1,5 @@
+import os
+
 import numpy as np
 
 from pytissueoptics.rayscattering.opencl import CLObjects as clObjects, CONFIG
@@ -13,8 +15,9 @@ class CLParameters:
         self._maxLoggerMemory = avgPhotonsPerBatch * AVG_IT_PER_PHOTON * DATAPOINT_SIZE
         self._maxLoggerMemory = min(self._maxLoggerMemory, CONFIG.MAX_MEMORY)
         self._maxPhotonsPerBatch = min(2 * avgPhotonsPerBatch, N)
-
         self._workItemAmount = CONFIG.N_WORK_UNITS
+
+        self._assertEnoughRAM()
 
     @property
     def workItemAmount(self):
@@ -68,7 +71,14 @@ class CLParameters:
 
     @property
     def requiredRAMBytes(self) -> float:
-        concatenationFactor = 2
         averageNBatches = int(1.3 * (1 / CONFIG.BATCH_LOAD_FACTOR))
+        concatenationFactor = 2
         overHead = 1.15
         return overHead * concatenationFactor * averageNBatches * self._maxLoggerMemory
+
+    def _assertEnoughRAM(self):
+        freeSystemRAM = int(os.popen('free -t -b').readlines()[-1].split()[3])
+        if self.requiredRAMBytes > 0.9 * freeSystemRAM:
+            warnings.warn(f"WARNING: Available system RAM might not be enough for the simulation. "
+                          f"Estimated requirement: {self.requiredRAMBytes // 1024**2} MB, "
+                          f"Available: {freeSystemRAM // 1024**2} MB.")

--- a/pytissueoptics/rayscattering/opencl/CLProgram.py
+++ b/pytissueoptics/rayscattering/opencl/CLProgram.py
@@ -2,6 +2,8 @@ import os
 import time
 from typing import List
 
+import numpy as np
+
 try:
     import pyopencl as cl
 except ImportError:
@@ -56,9 +58,9 @@ class CLProgram:
 
         self._program = cl.Program(self._context, sourceCode).build()
 
-    def getData(self, _object: CLObject):
+    def getData(self, _object: CLObject, dtype: np.dtype = np.float32):
         cl.enqueue_copy(self._mainQueue, dest=_object.hostBuffer, src=_object.deviceBuffer)
-        return rfn.structured_to_unstructured(_object.hostBuffer)
+        return rfn.structured_to_unstructured(_object.hostBuffer, dtype=dtype)
 
     @staticmethod
     def _makeSource(sourcePath) -> str:


### PR DESCRIPTION
Reduced RAM usage by a factor around 2.5x. 

While the batching prevents the OpenCL device to run out of memory, the concatenation of all batch loggers (done on CPU after the OpenCL propagation) can require a lot of RAM and potentially crash the program. I optimized data types, references and garbage collection to reduce RAM usage. This also speeds up the processing of the logger in some cases where RAM overflowed to swap memory. 