### PR TITLE
Reduce RAM Usage

### DIFF
--- a/pytissueoptics/rayscattering/opencl/CLKeyLog.py
+++ b/pytissueoptics/rayscattering/opencl/CLKeyLog.py
@@ -17,7 +17,8 @@ class CLKeyLog:
 
         self._keyIndices = []
         self._keyLog = {}
-        self._nBatch = 1000
+
+        self._batchSize = min(50000, len(self._log))
 
         self._extractKeyLog()
 
@@ -108,7 +109,3 @@ class CLKeyLog:
 
     def _getInteractionKey(self, solidID: int, surfaceID: int):
         return InteractionKey(self._sceneCL.getSolidLabel(solidID), self._sceneCL.getSurfaceLabel(solidID, surfaceID))
-
-    @property
-    def _batchSize(self):
-        return max(1, self._log.shape[0] // self._nBatch)

--- a/pytissueoptics/rayscattering/opencl/CLParameters.py
+++ b/pytissueoptics/rayscattering/opencl/CLParameters.py
@@ -71,14 +71,13 @@ class CLParameters:
 
     @property
     def requiredRAMBytes(self) -> float:
-        averageNBatches = int(1.3 * (1 / CONFIG.BATCH_LOAD_FACTOR))
-        concatenationFactor = 2
+        averageNBatches = 1.4 * (1 / CONFIG.BATCH_LOAD_FACTOR)
         overHead = 1.15
-        return overHead * concatenationFactor * averageNBatches * self._maxLoggerMemory
+        return overHead * averageNBatches * self._maxLoggerMemory
 
     def _assertEnoughRAM(self):
         freeSystemRAM = psutil.virtual_memory().available
-        if self.requiredRAMBytes > 0.9 * freeSystemRAM:
+        if self.requiredRAMBytes > 0.8 * freeSystemRAM:
             warnings.warn(f"WARNING: Available system RAM might not be enough for the simulation. "
                           f"Estimated requirement: {self.requiredRAMBytes // 1024**2} MB, "
                           f"Available: {freeSystemRAM // 1024**2} MB.")


### PR DESCRIPTION
Reduced RAM usage again of OpenCL propagation, by a factor around 1.9x, without affecting speed.

### Changes
- During batch propagation, do not append openCL logger data to a list for post-processing. Instead, process each openCL batch log immediately. By 'process' I mean translating the raw datapoints to scene logger InteractionKey datapoints. This removes the need to concatenate log arrays, which (almost) halves the RAM requirement.
- CLKeyLog translation use to split each log in 1000 batches to speed up the sorting algorithm. This turns out to be not always optimal, particularly now that I translate smaller logs. So I defined batchSize instead and set it to 50k datapoints. With that and the point above, the overall propagation time is still similar or slightly faster than before.
