### PR TITLE
Bug fixes

### DIFF
--- a/examples/rayscattering/accelerated/exampleComplex.py
+++ b/examples/rayscattering/accelerated/exampleComplex.py
@@ -19,8 +19,8 @@ else:
     material1 = ScatteringMaterial(mu_s=1.5, mu_a=1, g=0.9, n=1.4)
     material2 = ScatteringMaterial(mu_s=2.5, mu_a=1, g=0.9, n=1.7)
 
-cube = Cuboid(a=3, b=3, c=3, position=Vector(0, 0, 0), material=material1, label="Cube")
-sphere = Sphere(radius=1, order=3, position=Vector(0, 0, 0), material=material2, label="Sphere",
+cube = Cuboid(a=3, b=3, c=3, position=Vector(0, 0, 0), material=material1, label="cube")
+sphere = Sphere(radius=1, order=3, position=Vector(0, 0, 0), material=material2, label="sphere",
                 smooth=True)
 scene = ScatteringScene([cube, sphere])
 
@@ -34,5 +34,5 @@ viewer = Viewer(scene, source, logger)
 viewer.reportStats()
 
 viewer.show2D(View2DProjectionY())
-viewer.show2D(View2DProjectionY(solidLabel="Sphere"))
+viewer.show2D(View2DProjectionY(solidLabel="sphere"))
 viewer.show3D()

--- a/pytissueoptics/rayscattering/display/profiles/profileFactory.py
+++ b/pytissueoptics/rayscattering/display/profiles/profileFactory.py
@@ -128,6 +128,11 @@ class ProfileFactory:
 
         originalSurfaceLabels = self._logger.getSeenSurfaceLabels(solidLabel)
         lowerCaseSurfaceLabels = [l.lower() for l in originalSurfaceLabels]
+
+        altLabel = f'{solidLabel}_{surfaceLabel}'
+        if altLabel.lower() in lowerCaseSurfaceLabels:
+            surfaceLabel = altLabel
+
         if surfaceLabel.lower() in lowerCaseSurfaceLabels:
             labelIndex = lowerCaseSurfaceLabels.index(surfaceLabel.lower())
             surfaceLabel = originalSurfaceLabels[labelIndex]

--- a/pytissueoptics/rayscattering/display/views/viewFactory.py
+++ b/pytissueoptics/rayscattering/display/views/viewFactory.py
@@ -50,7 +50,7 @@ class ViewFactory:
         return views
 
     def _getDefaultSurfaceViews(self, solidLabel: str, surfaceLabel: str,
-                               includeLeaving: bool, includeEntering: bool, takenFromSolid: str = None) -> List[View2D]:
+                                includeLeaving: bool, includeEntering: bool, takenFromSolid: str = None) -> List[View2D]:
         if takenFromSolid is None:
             takenFromSolid = solidLabel
         surfaceNormal = self._getSurfaceNormal(takenFromSolid, surfaceLabel)
@@ -112,6 +112,10 @@ class ViewFactory:
         for containedSolidLabel in self._scene.getContainedSolidLabels(view.solidLabel):
             if view.surfaceLabel in self._scene.getSurfaceLabels(containedSolidLabel):
                 return True
+
+        if view.solidLabel not in view.surfaceLabel:
+            view._surfaceLabel = solid.completeSurfaceLabel(view.surfaceLabel)
+            return self._viewHasValidSurfaceLabel(view)
         return False
 
     @staticmethod

--- a/pytissueoptics/rayscattering/display/views/viewFactory.py
+++ b/pytissueoptics/rayscattering/display/views/viewFactory.py
@@ -91,7 +91,7 @@ class ViewFactory:
         if view.solidLabel:
             solid = self._scene.getSolid(view.solidLabel)
             limits3D = solid.getBoundingBox().xyzLimits
-            if view.surfaceLabel and view.surfaceLabel not in solid.surfaceLabels:
+            if not self._viewHasValidSurfaceLabel(view):
                 utils.warn("Surface label '{}' not found in solid '{}'. Available surface labels: {}".format(
                     view.surfaceLabel, view.solidLabel, solid.surfaceLabels))
         else:
@@ -102,6 +102,17 @@ class ViewFactory:
                 limits3D = sceneBoundingBox.xyzLimits
         limits3D = [(d[0], d[1]) for d in limits3D]
         view.setContext(limits3D=limits3D, binSize3D=self._defaultBinSize3D)
+
+    def _viewHasValidSurfaceLabel(self, view) -> bool:
+        if view.surfaceLabel is None:
+            return True
+        solid = self._scene.getSolid(view.solidLabel)
+        if view.surfaceLabel in solid.surfaceLabels:
+            return True
+        for containedSolidLabel in self._scene.getContainedSolidLabels(view.solidLabel):
+            if view.surfaceLabel in self._scene.getSurfaceLabels(containedSolidLabel):
+                return True
+        return False
 
     @staticmethod
     def _getDefaultViewsXYZ(solidLabel: str = None) -> List[View2D]:

--- a/pytissueoptics/rayscattering/opencl/config/CLConfig.py
+++ b/pytissueoptics/rayscattering/opencl/config/CLConfig.py
@@ -75,7 +75,9 @@ class CLConfig:
                 self._config["DEVICE_INDEX"] = None
                 return self._validateDeviceIndex()
         elif numberOfDevices == 0:
-            raise ValueError("No OpenCL devices found. Please install the OpenCL drivers for your hardware.")
+            raise ValueError("No OpenCL devices found. Please install the OpenCL drivers for your hardware or "
+                             "disable hardware acceleration by creating a light source with the argument "
+                             "`useHardwareAcceleration=False`.")
         elif numberOfDevices == 1:
             self._showAvailableDevices()
             warnings.warn(

--- a/pytissueoptics/rayscattering/scatteringScene.py
+++ b/pytissueoptics/rayscattering/scatteringScene.py
@@ -9,8 +9,8 @@ from pytissueoptics.scene.solids import Solid
 
 
 class ScatteringScene(Scene):
-    def __init__(self, solids: List[Solid], worldMaterial=ScatteringMaterial()):
-        super().__init__(solids, worldMaterial=worldMaterial)
+    def __init__(self, solids: List[Solid], worldMaterial=ScatteringMaterial(), ignoreIntersections: bool = False):
+        super().__init__(solids, worldMaterial=worldMaterial, ignoreIntersections=ignoreIntersections)
 
     def add(self, solid: Solid, position: Vector = None):
         polygonSample = solid.getPolygons()[0]

--- a/pytissueoptics/rayscattering/scatteringScene.py
+++ b/pytissueoptics/rayscattering/scatteringScene.py
@@ -19,8 +19,8 @@ class ScatteringScene(Scene):
                             f"This is required for any RayScatteringScene. ")
         super().add(solid, position)
 
-    def addToViewer(self, viewer: MayaviViewer):
-        viewer.add(*self.solids, representation="surface", colormap="bone", opacity=0.1)
+    def addToViewer(self, viewer: MayaviViewer, representation='surface', colormap='bone', opacity=0.1, **kwargs):
+        viewer.add(*self.solids, representation=representation, colormap=colormap, opacity=opacity, **kwargs)
 
     def display(self):
         viewer = MayaviViewer()

--- a/pytissueoptics/rayscattering/source.py
+++ b/pytissueoptics/rayscattering/source.py
@@ -148,9 +148,10 @@ class Source:
     def getPhotonCount(self) -> int:
         return self._N
 
-    def addToViewer(self, viewer: MayaviViewer, size: float = 0.1):
+    def addToViewer(self, viewer: MayaviViewer, size: float = 0.1,
+                    representation='surface', colormap='Wistia', opacity=0.8, **kwargs):
         sphere = Sphere(radius=size/2, position=self._position)
-        viewer.add(sphere, representation="surface", colormap="Wistia", opacity=0.8)
+        viewer.add(sphere, representation=representation, colormap=colormap, opacity=opacity, **kwargs)
 
     @property
     def _nameHash(self) -> int:

--- a/pytissueoptics/rayscattering/tests/display/testProfileFactory.py
+++ b/pytissueoptics/rayscattering/tests/display/testProfileFactory.py
@@ -160,7 +160,7 @@ class TestProfileFactory(unittest.TestCase):
     def testGiven2DLogger_whenCreateSurfaceProfile_shouldExtractSolidProfileFromLoggerData(self):
         self.TEST_LOGGER = EnergyLogger(self.TEST_SCENE, keep3D=False, defaultBinSize=1.0)
         surfaceData = np.array([[1, 1.5, 1.5, 1.5], [-1, -1.5, -1.5, -1.5]])
-        self.TEST_LOGGER.logDataPointArray(surfaceData, InteractionKey("cube", "top"))
+        self.TEST_LOGGER.logDataPointArray(surfaceData, InteractionKey("cube", "cube_top"))
         self.profileFactory = ProfileFactory(self.TEST_SCENE, self.TEST_LOGGER)
 
         expectedSurfaceDataLeaving = np.array([0, 0, 0, 1])

--- a/pytissueoptics/rayscattering/tests/display/testViewFactory.py
+++ b/pytissueoptics/rayscattering/tests/display/testViewFactory.py
@@ -39,6 +39,7 @@ class TestViewFactory(unittest.TestCase):
     def testWhenBuildAViewWithSolidLabel_shouldSetContextWithSolidLimits(self):
         sceneView = mock(View2D)
         sceneView.solidLabel = self.TEST_CUBE.getLabel()
+        sceneView.surfaceLabel = None
         when(sceneView).setContext(...).thenReturn()
 
         self.viewFactory.build([sceneView])

--- a/pytissueoptics/rayscattering/tests/display/testViewFactory.py
+++ b/pytissueoptics/rayscattering/tests/display/testViewFactory.py
@@ -84,14 +84,14 @@ class TestViewFactory(unittest.TestCase):
         #  and another view of the energy leaving from the cube and into the sphere
         surfaceLeavingViews = self.viewFactory.build(ViewGroup.SURFACES_LEAVING)
 
-        expectedViews = [View2DSurfaceX("cube", "left"),
-                         View2DSurfaceX("cube", "right"),
-                         View2DSurfaceY("cube", "bottom"),
-                         View2DSurfaceY("cube", "top"),
-                         View2DSurfaceZ("cube", "front"),
-                         View2DSurfaceZ("cube", "back"),
-                         View2DSurfaceZ("cube", "ellipsoid"),
-                         View2DSurfaceZ("sphere", "ellipsoid")]
+        expectedViews = [View2DSurfaceX("cube", "cube_left"),
+                         View2DSurfaceX("cube", "cube_right"),
+                         View2DSurfaceY("cube", "cube_bottom"),
+                         View2DSurfaceY("cube", "cube_top"),
+                         View2DSurfaceZ("cube", "cube_front"),
+                         View2DSurfaceZ("cube", "cube_back"),
+                         View2DSurfaceZ("cube", "sphere_ellipsoid"),
+                         View2DSurfaceZ("sphere", "sphere_ellipsoid")]
         expectedViews[1].flip()
         expectedViews[2].flip()
         expectedViews[5].flip()
@@ -106,14 +106,14 @@ class TestViewFactory(unittest.TestCase):
     def testWhenBuildASurfacesEnteringViewGroup_shouldCreateAndReturnTheDefaultEnteringSurfaceViewForEachSolidSurface(self):
         surfaceEnteringViews = self.viewFactory.build(ViewGroup.SURFACES_ENTERING)
 
-        expectedViews = [View2DSurfaceX("cube", "left", surfaceEnergyLeaving=False),
-                         View2DSurfaceX("cube", "right", surfaceEnergyLeaving=False),
-                         View2DSurfaceY("cube", "bottom", surfaceEnergyLeaving=False),
-                         View2DSurfaceY("cube", "top", surfaceEnergyLeaving=False),
-                         View2DSurfaceZ("cube", "front", surfaceEnergyLeaving=False),
-                         View2DSurfaceZ("cube", "back", surfaceEnergyLeaving=False),
-                         View2DSurfaceZ("cube", "ellipsoid", surfaceEnergyLeaving=False),
-                         View2DSurfaceZ("sphere", "ellipsoid", surfaceEnergyLeaving=False)]
+        expectedViews = [View2DSurfaceX("cube", "cube_left", surfaceEnergyLeaving=False),
+                         View2DSurfaceX("cube", "cube_right", surfaceEnergyLeaving=False),
+                         View2DSurfaceY("cube", "cube_bottom", surfaceEnergyLeaving=False),
+                         View2DSurfaceY("cube", "cube_top", surfaceEnergyLeaving=False),
+                         View2DSurfaceZ("cube", "cube_front", surfaceEnergyLeaving=False),
+                         View2DSurfaceZ("cube", "cube_back", surfaceEnergyLeaving=False),
+                         View2DSurfaceZ("cube", "sphere_ellipsoid", surfaceEnergyLeaving=False),
+                         View2DSurfaceZ("sphere", "sphere_ellipsoid", surfaceEnergyLeaving=False)]
         expectedViews[1].flip()
         expectedViews[2].flip()
         expectedViews[5].flip()

--- a/pytissueoptics/rayscattering/tests/energyLogging/testEnergyLogger.py
+++ b/pytissueoptics/rayscattering/tests/energyLogging/testEnergyLogger.py
@@ -64,7 +64,7 @@ class TestEnergyLogger(unittest.TestCase):
         self.logger = EnergyLogger(self.TEST_SCENE, keep3D=False, views=[sceneView, cubeView, surfaceView])
 
         self.logger.logDataPointArray(np.array([[1, 0, 0, 0]]), InteractionKey("cube"))
-        self.logger.logDataPointArray(np.array([[2, 0, 0, 0]]), InteractionKey("cube", "top"))
+        self.logger.logDataPointArray(np.array([[2, 0, 0, 0]]), InteractionKey("cube", "cube_top"))
         self.logger.logDataPointArray(np.array([[4, 0, 0, 0]]), InteractionKey("sphere"))
 
         self.assertEqual(1, cubeView.getSum())

--- a/pytissueoptics/rayscattering/tests/opencl/testCLPhotons.py
+++ b/pytissueoptics/rayscattering/tests/opencl/testCLPhotons.py
@@ -56,14 +56,14 @@ class TestCLPhotons(unittest.TestCase):
 
         photons.propagate(IPP=IPP, verbose=False)
 
-        frontSurfacePoints = logger.getDataPoints(InteractionKey("cube", "front"))
+        frontSurfacePoints = logger.getDataPoints(InteractionKey("cube", "cube_front"))
         energyInput = -np.sum(frontSurfacePoints[:, 0])  # should be around 97% of total energy because of reflections
         cubePoints = logger.getDataPoints(InteractionKey("cube"))
         energyScattered = np.sum(cubePoints[:, 0])
 
         energyLeaving = 0
         for surfaceLabel in logger.getStoredSurfaceLabels("cube"):
-            if surfaceLabel == "front":
+            if "front" in surfaceLabel:
                 continue
             surfacePoints = logger.getDataPoints(InteractionKey("cube", surfaceLabel))
             energyLeaving += np.sum(surfacePoints[:, 0])

--- a/pytissueoptics/rayscattering/tests/statistics/testStats.py
+++ b/pytissueoptics/rayscattering/tests/statistics/testStats.py
@@ -16,11 +16,11 @@ from pytissueoptics.scene.solids import Cube
 
 class TestStats(unittest.TestCase):
     EXPECTED_SOLID_REPORT_LINES = ["Report of solid 'cube'",
-                               "  Absorbance: 80.00% (80.00% of total power)",
-                               "  Absorbance + Transmittance: 100.0%",
-                               "    Transmittance at 'front': 0.0%",
-                               "    Transmittance at 'back': 20.0%",
-                               '']
+                                   "  Absorbance: 80.00% (80.00% of total power)",
+                                   "  Absorbance + Transmittance: 100.0%",
+                                   "    Transmittance at 'cube_front': 0.0%",
+                                   "    Transmittance at 'cube_back': 20.0%",
+                                   '']
     EXPECTED_REPORT_LINES = EXPECTED_SOLID_REPORT_LINES[:-1] + ["Report of 'world'",
                                                                 "  Absorbed 20.00% of total power",
                                                                 '']
@@ -56,7 +56,7 @@ class TestStats(unittest.TestCase):
     def testGiven2DLoggerWithNoViewsOfSurface_whenGetTransmittanceOfSurface_shouldRaiseException(self):
         self._setUp(keep3D=False, noViews=True)
         with self.assertRaises(Exception):
-            self.stats.getTransmittance("cube", "front")
+            self.stats.getTransmittance("cube", "cube_front")
 
     def testGivenSourceInSolid_whenGetEnergyInput_shouldAddSourceEnergyToSolidInputEnergy(self):
         for keep3D in [False, True]:
@@ -81,8 +81,8 @@ class TestStats(unittest.TestCase):
         for keep3D in [False, True]:
             with self.subTest(["using2DLogger", "using3DLogger"][keep3D]):
                 self._setUp(keep3D=keep3D)
-                self.assertAlmostEqual(0, self.stats.getTransmittance("cube", "front"), places=5)
-                self.assertAlmostEqual(20, self.stats.getTransmittance("cube", "back"), places=5)
+                self.assertAlmostEqual(0, self.stats.getTransmittance("cube", "cube_front"), places=5)
+                self.assertAlmostEqual(20, self.stats.getTransmittance("cube", "cube_back"), places=5)
 
     def testWhenReportSolid_shouldPrintAFullReportOfThisSolidAndItsSurfaces(self):
         for keep3D in [False, True]:
@@ -136,8 +136,8 @@ class TestStats(unittest.TestCase):
         if noViews:
             logger = EnergyLogger(scene, keep3D=keep3D, views=[])
         solidInteraction = InteractionKey("cube")
-        frontInteraction = InteractionKey("cube", "front")
-        backInteraction = InteractionKey("cube", "back")
+        frontInteraction = InteractionKey("cube", "cube_front")
+        backInteraction = InteractionKey("cube", "cube_back")
         for i in range(1, 9):
             logger.logDataPoint(0.1, Vector(0, 0, 0.1*i), solidInteraction)
         logger.logDataPoint(-1, Vector(0, 0, 0), frontInteraction)
@@ -145,6 +145,6 @@ class TestStats(unittest.TestCase):
         logger.info["photonCount"] = 1
         logger.info["sourceSolidLabel"] = sourceSolidLabel
 
-        # Logging the energy that left the solid in the outside world
+        # Logging the energy that left the solid on the outside world
         logger.logDataPoint(0.2, Vector(0, 0, 10), InteractionKey("world"))
         return logger

--- a/pytissueoptics/scene/geometry/bbox.py
+++ b/pytissueoptics/scene/geometry/bbox.py
@@ -169,6 +169,30 @@ class BoundingBox:
         if other.zMax < self.zMax:
             self._zLim[1] = other.zMax
 
+    def exclude(self, other: 'BoundingBox'):
+        if not self.intersects(other):
+            return
+
+        largestArea = 0
+        currentBBox = None
+        for axis in range(3):
+            leftLimits = [self[axis][0], other[axis][0]]
+            rightLimits = [other[axis][1], self[axis][1]]
+            leftLength = leftLimits[1] - leftLimits[0]
+            rightLength = rightLimits[1] - rightLimits[0]
+            croppedLimits = leftLimits if leftLength > rightLength else rightLimits
+            newXYZLimits = self._xyzLimits.copy()
+            newXYZLimits[axis] = croppedLimits
+            newBBox = BoundingBox(*newXYZLimits)
+            boxArea = newBBox.getArea()
+            if boxArea > largestArea:
+                largestArea = boxArea
+                currentBBox = newBBox
+
+        for axis in range(3):
+            self._xyzLimits[axis][0] = currentBBox[axis][0]
+            self._xyzLimits[axis][1] = currentBBox[axis][1]
+
     def __getitem__(self, index: int) -> List[float]:
         return self._xyzLimits[index]
 

--- a/pytissueoptics/scene/geometry/surfaceCollection.py
+++ b/pytissueoptics/scene/geometry/surfaceCollection.py
@@ -27,7 +27,7 @@ class SurfaceCollection:
 
     def getPolygons(self, surfaceLabel: str = None) -> List[Polygon]:
         if surfaceLabel:
-            surfaceLabel = self._processLabel(surfaceLabel)
+            surfaceLabel = self.processLabel(surfaceLabel)
             self._assertContains(surfaceLabel)
             return self._surfaces[surfaceLabel]
         else:
@@ -37,7 +37,7 @@ class SurfaceCollection:
             return allPolygons
 
     def setPolygons(self, surfaceLabel: str, polygons: List[Polygon]):
-        surfaceLabel = self._processLabel(surfaceLabel)
+        surfaceLabel = self.processLabel(surfaceLabel)
         self._assertContains(surfaceLabel)
         for polygon in polygons:
             polygon.surfaceLabel = surfaceLabel
@@ -108,7 +108,7 @@ class SurfaceCollection:
         for polygon in self._surfaces[newLabel]:
             polygon.surfaceLabel = newLabel
 
-    def _processLabel(self, surfaceLabel: str):
+    def processLabel(self, surfaceLabel: str):
         if surfaceLabel is None:
             return None
         if surfaceLabel in self.surfaceLabels:

--- a/pytissueoptics/scene/geometry/surfaceCollection.py
+++ b/pytissueoptics/scene/geometry/surfaceCollection.py
@@ -12,6 +12,7 @@ INTERFACE_KEY = "interface"
 class SurfaceCollection:
     def __init__(self):
         self._surfaces: Dict[str, List[Polygon]] = {}
+        self._solidLabel = None
 
     @property
     def surfaceLabels(self) -> List[str]:
@@ -26,6 +27,7 @@ class SurfaceCollection:
 
     def getPolygons(self, surfaceLabel: str = None) -> List[Polygon]:
         if surfaceLabel:
+            surfaceLabel = self._processLabel(surfaceLabel)
             self._assertContains(surfaceLabel)
             return self._surfaces[surfaceLabel]
         else:
@@ -35,6 +37,7 @@ class SurfaceCollection:
             return allPolygons
 
     def setPolygons(self, surfaceLabel: str, polygons: List[Polygon]):
+        surfaceLabel = self._processLabel(surfaceLabel)
         self._assertContains(surfaceLabel)
         for polygon in polygons:
             polygon.surfaceLabel = surfaceLabel
@@ -90,3 +93,26 @@ class SurfaceCollection:
         while f"{surfaceLabel}_{idx}" in self.surfaceLabels:
             idx += 1
         return f"{surfaceLabel}_{idx}"
+
+    def updateSolidLabel(self, label):
+        for surfaceLabel in self.surfaceLabels:
+            labelComponents = surfaceLabel.split("_")
+            if labelComponents[0] == self._solidLabel:
+                labelComponents.pop(0)
+            newSurfaceLabel = "_".join([label] + labelComponents)
+            self._updateLabel(surfaceLabel, newSurfaceLabel)
+        self._solidLabel = label
+
+    def _updateLabel(self, oldLabel: str, newLabel: str):
+        self._surfaces[newLabel] = self._surfaces.pop(oldLabel)
+        for polygon in self._surfaces[newLabel]:
+            polygon.surfaceLabel = newLabel
+
+    def _processLabel(self, surfaceLabel: str):
+        if surfaceLabel is None:
+            return None
+        if surfaceLabel in self.surfaceLabels:
+            return surfaceLabel
+        if self._solidLabel in surfaceLabel:
+            return surfaceLabel
+        return f"{self._solidLabel}_{surfaceLabel}"

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -58,7 +58,11 @@ class Scene:
                 self._assertIsNotAStack(otherSolid)
                 self._processContainedSolid(newSolid, container=otherSolid)
             else:
-                raise NotImplementedError("Cannot place a solid that partially intersects with an existing solid. ")
+                raise NotImplementedError("Cannot place a solid that partially intersects with an existing solid. "
+                                          "Since this might be underestimating containment, you can also create a "
+                                          "scene with 'ignoreIntersections=True' to ignore this error and manually "
+                                          "handle environments of contained solids with "
+                                          "containedSolid.setOutsideEnvironment(containerSolid.getEnvironment()).")
 
     def _processContainedSolid(self, solid: Solid, container: Solid):
         solid.setOutsideEnvironment(container.getEnvironment())

--- a/pytissueoptics/scene/solids/cuboid.py
+++ b/pytissueoptics/scene/solids/cuboid.py
@@ -82,7 +82,7 @@ class Cuboid(Solid):
         cuboid._layerLabels = stackResult.layerLabels
         return cuboid
 
-    def contains(self, *vertices: Vertex) -> bool:
+    def contains(self, *vertices: Vector) -> bool:
         vertices = np.asarray([vertex.array for vertex in vertices])
         relativeVertices = vertices - self.position.array
 

--- a/pytissueoptics/scene/solids/cuboid.py
+++ b/pytissueoptics/scene/solids/cuboid.py
@@ -22,7 +22,7 @@ class Cuboid(Solid):
 
     def __init__(self, a: float, b: float, c: float,
                  vertices: List[Vertex] = None, position: Vector = Vector(0, 0, 0), surfaces: SurfaceCollection = None,
-                 material=None, label: str = "cuboid", primitive: str = primitives.DEFAULT):
+                 material=None, label: str = "cuboid", primitive: str = primitives.DEFAULT, labelOverride=True):
 
         self.shape = [a, b, c]
 
@@ -32,7 +32,7 @@ class Cuboid(Solid):
                         Vertex(-a / 2, -b / 2, -c / 2), Vertex(a / 2, -b / 2, -c / 2), Vertex(a / 2, b / 2, -c / 2),
                         Vertex(-a / 2, b / 2, -c / 2)]
 
-        super().__init__(vertices, position, surfaces, material, label, primitive)
+        super().__init__(vertices, position, surfaces, material, label, primitive, labelOverride=labelOverride)
 
     def _computeTriangleMesh(self):
         V = self._vertices
@@ -78,7 +78,7 @@ class Cuboid(Solid):
             vertex.subtract(stackResult.position)
 
         cuboid = Cuboid(*stackResult.shape, position=stackResult.position, vertices=stackResult.vertices,
-                        surfaces=stackResult.surfaces, label=label, primitive=stackResult.primitive)
+                        surfaces=stackResult.surfaces, label=label, primitive=stackResult.primitive, labelOverride=False)
         cuboid._layerLabels = stackResult.layerLabels
         return cuboid
 

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -1,4 +1,5 @@
 import math
+import warnings
 from typing import List
 
 from pytissueoptics.scene.geometry import Vector, Triangle, primitives, Vertex
@@ -8,7 +9,7 @@ from pytissueoptics.scene.solids import Solid
 class Cylinder(Solid):
     def __init__(self, radius: float = 1, height: float = 1, u: int = 32, v: int = 3,
                  position: Vector = Vector(0, 0, 0), material=None,
-                 primitive: str = primitives.DEFAULT, label: str = "cylinder"):
+                 primitive: str = primitives.DEFAULT, label: str = "cylinder", smooth=True):
         self._radius = radius
         self._height = height
         if u < 3 or v < 1:
@@ -19,7 +20,7 @@ class Cylinder(Solid):
         self._topCenter = Vertex(0, 0, height)
         self._minRadius = math.cos(math.pi / self._u) * self._radius
         super().__init__(position=position, material=material, primitive=primitive,
-                         vertices=[self._bottomCenter, self._topCenter], smooth=True, label=label)
+                         vertices=[self._bottomCenter, self._topCenter], smooth=smooth, label=label)
         self.translateBy(Vector(0, 0, -height / 2))
         self._position += Vector(0, 0, height / 2)
 
@@ -110,4 +111,6 @@ class Cylinder(Solid):
         return 1
 
     def smooth(self, surfaceLabel: str = None):
+        if self._u < 16:
+            warnings.warn("Smoothing a cylinder with less than 16 sides (u < 16) may result in intersection errors.")
         super(Cylinder, self).smooth("middle")

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -20,6 +20,8 @@ class Cylinder(Solid):
         self._minRadius = math.cos(math.pi / self._u) * self._radius
         super().__init__(position=position, material=material, primitive=primitive,
                          vertices=[self._bottomCenter, self._topCenter], smooth=True, label=label)
+        self.translateBy(Vector(0, 0, -height / 2))
+        self._position += Vector(0, 0, height / 2)
 
     @property
     def direction(self) -> Vector:

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -8,7 +8,7 @@ from pytissueoptics.scene.solids import Solid
 class Cylinder(Solid):
     def __init__(self, radius: float = 1, height: float = 1, u: int = 32, v: int = 3,
                  position: Vector = Vector(0, 0, 0), material=None,
-                 primitive: str = primitives.DEFAULT, label: str = "Cylinder"):
+                 primitive: str = primitives.DEFAULT, label: str = "cylinder"):
         self._radius = radius
         self._height = height
         if u < 3 or v < 1:

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -65,6 +65,7 @@ class Cylinder(Solid):
         self._surfaces.add("middle", middleTriangles)
 
     def _computeBottomTriangles(self, vertices: List[Vertex]):
+        vertices.reverse()
         bottomTriangles = []
         for i in range(self._u):
             nextIndex = (i + 1) % self._u

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -82,7 +82,7 @@ class Cylinder(Solid):
     def _computeQuadMesh(self):
         raise NotImplementedError("Quad mesh not implemented for Cylinder")
 
-    def contains(self, *vertices: Vertex) -> bool:
+    def contains(self, *vertices: Vector) -> bool:
         for vertex in vertices:
             direction = self.direction
             direction.normalize()

--- a/pytissueoptics/scene/solids/ellipsoid.py
+++ b/pytissueoptics/scene/solids/ellipsoid.py
@@ -150,7 +150,7 @@ class Ellipsoid(Solid):
     def _computeQuadMesh(self):
         raise NotImplementedError
 
-    def contains(self, *vertices: Vertex) -> bool:
+    def contains(self, *vertices: Vector) -> bool:
         """ Only returns true if all vertices are inside the minimum radius of the ellipsoid
         towards each vertex direction (more restrictive with low order ellipsoids). """
         verticesArray = np.asarray([vertex.array for vertex in vertices])

--- a/pytissueoptics/scene/solids/ellipsoid.py
+++ b/pytissueoptics/scene/solids/ellipsoid.py
@@ -162,6 +162,7 @@ class Ellipsoid(Solid):
         for relativeVertexArray in relativeVerticesArray:
             relativeVertex = Vertex(*relativeVertexArray)
             vertexRadius = relativeVertex.getNorm()
+            relativeVertex.normalize()
             if vertexRadius == 0:
                 continue
             minRadius = self._getMinimumRadiusTowards(relativeVertex)

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -29,6 +29,7 @@ class Solid:
         self._resetBoundingBoxes()
         self._resetPolygonsCentroids()
 
+        self._smoothing = False
         if smooth:
             self.smooth()
 
@@ -119,6 +120,9 @@ class Solid:
         self._resetBoundingBoxes()
         self._resetPolygonsCentroids()
 
+        if self._smoothing:
+            self.smooth()
+
     def getEnvironment(self, surfaceLabel: str = None) -> Environment:
         if surfaceLabel:
             return self.surfaces.getInsideEnvironment(surfaceLabel)
@@ -206,6 +210,9 @@ class Solid:
         be changed by overwriting the signature with a specific surfaceLabel in
         another solid implementation and calling super().smooth(surfaceLabel).
         """
+        self._smoothing = True
+        for vertex in self.vertices:
+            vertex.normal = None
 
         polygons = self.getPolygons(surfaceLabel)
 

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -179,8 +179,8 @@ class Solid:
     def _computeQuadMesh(self):
         raise NotImplementedError(f"Quad mesh not implemented for Solids of type {type(self).__name__}")
 
-    def contains(self, *vertices: Vertex) -> bool:
         # todo: implement basic contain with polygon bboxes
+    def contains(self, *vertices: Vector) -> bool:
         warnings.warn(f"Method contains(Vertex) is not implemented for Solids of type {type(self).__name__}. "
                       "Returning False", RuntimeWarning)
         return False

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -10,7 +10,7 @@ from pytissueoptics.scene.geometry import primitives, Environment, SurfaceCollec
 class Solid:
     def __init__(self, vertices: List[Vertex], position: Vector = Vector(0, 0, 0),
                  surfaces: SurfaceCollection = None, material=None,
-                 label: str = "solid", primitive: str = primitives.DEFAULT, smooth: bool = False):
+                 label: str = "solid", primitive: str = primitives.DEFAULT, smooth: bool = False, labelOverride=True):
         self._vertices = vertices
         self._surfaces = surfaces
         self._material = material
@@ -23,7 +23,10 @@ class Solid:
 
         if not self._surfaces:
             self._computeMesh()
+        if labelOverride:
             self.setLabel(label)
+        else:
+            self._surfaces._solidLabel = ""
 
         self.translateTo(position)
         self._setInsideEnvironment()

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -218,6 +218,9 @@ class Solid:
     def getLayerSurfaceLabels(self, layerSolidLabel) -> List[str]:
         return list(self._layerLabels[layerSolidLabel])
 
+    def completeSurfaceLabel(self, surfaceLabel: str) -> str:
+        return self._surfaces.processLabel(surfaceLabel)
+
     def smooth(self, surfaceLabel: str = None):
         """ Prepare smoothing by calculating vertex normals. This is not done
         by default. The vertex normals are used during ray-polygon intersection

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -23,6 +23,7 @@ class Solid:
 
         if not self._surfaces:
             self._computeMesh()
+            self.setLabel(label)
 
         self.translateTo(position)
         self._setInsideEnvironment()
@@ -63,6 +64,7 @@ class Solid:
         return self._label
 
     def setLabel(self, label: str):
+        self._surfaces.updateSolidLabel(label)
         self._label = label
 
     def _resetBoundingBoxes(self):

--- a/pytissueoptics/scene/solids/sphere.py
+++ b/pytissueoptics/scene/solids/sphere.py
@@ -29,7 +29,7 @@ class Sphere(Ellipsoid):
     def _computeQuadMesh(self):
         raise NotImplementedError
 
-    def contains(self, *vertices: Vertex) -> bool:
+    def contains(self, *vertices: Vector) -> bool:
         """ Only returns true if all vertices are inside the minimum radius of the sphere
         (more restrictive with low order spheres). """
         minRadius = self._getMinimumRadius()

--- a/pytissueoptics/scene/solids/stack/cuboidStacker.py
+++ b/pytissueoptics/scene/solids/stack/cuboidStacker.py
@@ -27,6 +27,7 @@ class CuboidStacker:
         assert onSurfaceLabel in self.SURFACE_KEYS, f"Available surfaces to stack on are: {self.SURFACE_KEYS}"
         self._onCuboid = onCuboid
         self._otherCuboid = otherCuboid
+        self._assertNoDuplicateLabel()
 
         self._stackAxis = self._getSurfaceAxis(onSurfaceLabel)
         self._onSurfaceLabel = onSurfaceLabel
@@ -35,6 +36,18 @@ class CuboidStacker:
         self._newInterfaceIndex = len(onCuboidInterfaces)
 
         self._validateShapeMatch()
+
+    def _assertNoDuplicateLabel(self):
+        onCuboidLayerLabels = self._onCuboid.getLayerLabels()
+        if not onCuboidLayerLabels:
+            onCuboidLayerLabels = [self._onCuboid.getLabel()]
+        otherCuboidLayerLabels = self._otherCuboid.getLayerLabels()
+        if not otherCuboidLayerLabels:
+            otherCuboidLayerLabels = [self._otherCuboid.getLabel()]
+
+        for label in onCuboidLayerLabels:
+            assert label not in otherCuboidLayerLabels, f"Found duplicate layer label in stack: {label}. " \
+                                                        f"Please rename one of the layers."
 
     def _getSurfaceAxis(self, surfaceLabel: str) -> int:
         return max(axis if surfaceLabel in surfacePair else -1 for axis, surfacePair in enumerate(self.SURFACE_PAIRS))

--- a/pytissueoptics/scene/tests/geometry/testBoundingBox.py
+++ b/pytissueoptics/scene/tests/geometry/testBoundingBox.py
@@ -117,6 +117,24 @@ class TestBoundingBox(unittest.TestCase):
 
         self.assertFalse(bbox.intersects(nonIntersectingBox))
 
+    def testWhenExcludeAnotherBBoxNotIntersecting_shouldNotChangeCurrentBBox(self):
+        bbox = BoundingBox([0, 5], [0, 5], [0, 5])
+        nonIntersectingBox = BoundingBox([5, 7], [0, 5], [1, 4])
+
+        bbox.exclude(nonIntersectingBox)
+        self.assertEqual(BoundingBox([0, 5], [0, 5], [0, 5]), bbox)
+
+    def testWhenExcludeAnotherBBoxIntersecting_shouldShrinkCurrentBBoxToExcludeTheOther(self):
+        bbox = BoundingBox([0, 5], [0, 5], [0, 5])
+
+        intersectingBox1 = BoundingBox([3, 4], [3, 4], [3, 4])
+        bbox.exclude(intersectingBox1)
+        self.assertEqual(BoundingBox([0, 3], [0, 5], [0, 5]), bbox)
+
+        intersectingBox2 = BoundingBox([2.5, 3.5], [2, 3], [2, 3])
+        bbox.exclude(intersectingBox2)
+        self.assertEqual(BoundingBox([0, 2.5], [0, 5], [0, 5]), bbox)
+
     def testWhenCopyBBox_newBboxShouldBeIdenticalButIndependent(self):
         bbox = BoundingBox([0, 5], [0, 5], [0, 5])
         newBbox = bbox.copy()

--- a/pytissueoptics/scene/tests/loader/testLoader.py
+++ b/pytissueoptics/scene/tests/loader/testLoader.py
@@ -33,7 +33,8 @@ class TestLoader(unittest.TestCase):
     def testWhenLoadingMultiGroupObject_shouldSplitCorrectGroups(self):
         loader = Loader()
         solids = loader.load(self._filepath("testCubeTrianglesMulti.obj"), showProgress=False)
-        self.assertCountEqual(["front", "back", "bottom", "top", "right", "left"], solids[0].surfaceLabels)
+        self.assertCountEqual(["cube_front", "cube_back", "cube_bottom",
+                               "cube_top", "cube_right", "cube_left"], solids[0].surfaceLabels)
 
     def testWhenLoadingMultiGroupObject_shouldHaveCorrectAmountOfElementsPerGroup(self):
         loader = Loader()

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -204,9 +204,9 @@ class TestScene(unittest.TestCase):
         self.assertEqual(self.scene.getWorldEnvironment(), env)
 
     def testWhenGetEnvironmentWithPositionContainedInAStack_shouldReturnEnvironmentOfProperStackLayer(self):
-        frontLayer = Cuboid(1, 1, 1, material="frontMaterial")
-        middleLayer = Cuboid(1, 1, 1, material="middleMaterial")
-        backLayer = Cuboid(1, 1, 1, material="backMaterial")
+        frontLayer = Cuboid(1, 1, 1, material="frontMaterial", label="frontLayer")
+        middleLayer = Cuboid(1, 1, 1, material="middleMaterial", label="middleLayer")
+        backLayer = Cuboid(1, 1, 1, material="backMaterial", label="backLayer")
         stack = backLayer.stack(middleLayer, 'front').stack(frontLayer, 'front')
         self.scene.add(stack, position=Vector(0, 0, 0))
 
@@ -355,8 +355,8 @@ class TestScene(unittest.TestCase):
 
     def testWhenGetMaterials_shouldReturnAllMaterialsPresentInTheScene(self):
         layerMaterials = ["Material1", "Material2"]
-        frontLayer = Cuboid(1, 1, 1, material=layerMaterials[0])
-        middleLayer = Cuboid(1, 1, 1, material=layerMaterials[1])
+        frontLayer = Cuboid(1, 1, 1, material=layerMaterials[0], label="Front Layer")
+        middleLayer = Cuboid(1, 1, 1, material=layerMaterials[1], label="Middle Layer")
         stack = middleLayer.stack(frontLayer, 'front')
         self.scene.add(stack)
 

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -227,14 +227,13 @@ class TestScene(unittest.TestCase):
 
         self.assertEqual(solid, returnedSolid)
 
-    def testWhenGetSolidFromLabelThatDoesNotExist_shouldReturnNone(self):
+    def testWhenGetSolidFromLabelThatDoesNotExist_shouldRaise(self):
         SOLID_LABEL = "Solid"
         solid = self.makeSolidWith(name=SOLID_LABEL)
         self.scene.add(solid)
 
-        returnedSolid = self.scene.getSolid("NonExistingLabel")
-
-        self.assertIsNone(returnedSolid)
+        with self.assertRaises(ValueError):
+            self.scene.getSolid("NonExistingLabel")
 
     def testWhenGetSolidFromLabelWithCapitalizationError_shouldReturnTheSolid(self):
         SOLID_LABEL_CAPITALIZED = "Solid"
@@ -292,14 +291,13 @@ class TestScene(unittest.TestCase):
 
         self.assertEqual(solid1.surfaceLabels, labels)
 
-    def testWhenGetSurfaceLabelsOfSolidThatDoesNotExist_shouldReturnNoLabels(self):
+    def testWhenGetSurfaceLabelsOfSolidThatDoesNotExist_shouldRaise(self):
         solid = self.makeSolidWith()
         solid.surfaceLabels = ["Surface1", "Surface2"]
         self.scene.add(solid)
 
-        labels = self.scene.getSurfaceLabels("NonExistingLabel")
-
-        self.assertEqual([], labels)
+        with self.assertRaises(ValueError):
+            self.scene.getSurfaceLabels("NonExistingLabel")
 
     def testWhenGetSurfaceLabelsOfAStack_shouldReturnTheSurfaceLabelsForAllItsLayers(self):
         STACK_LABEL = "Stack"

--- a/pytissueoptics/scene/tests/scene/testScene.py
+++ b/pytissueoptics/scene/tests/scene/testScene.py
@@ -218,6 +218,17 @@ class TestScene(unittest.TestCase):
         self.assertEqual(Environment("middleMaterial", middleLayer), middleEnv)
         self.assertEqual(Environment("backMaterial", backLayer), backEnv)
 
+    def testWhenGetEnvironmentWithPositionInsideAContainedSolid_shouldReturnEnvironmentOfThisContainedSolid(self):
+        SOLID = Cuboid(3, 3, 3, material="Material of solid", label="Solid")
+        CONTAINED_SOLID = Cuboid(2, 2, 2, material="Material of contained solid", label="Contained solid")
+
+        self.scene.add(SOLID)
+        self.scene.add(CONTAINED_SOLID)
+
+        env = self.scene.getEnvironmentAt(Vector(0, 0, 0))
+
+        self.assertEqual(CONTAINED_SOLID.getEnvironment(), env)
+
     def testWhenGetSolidFromLabel_shouldReturnTheSolid(self):
         SOLID_LABEL = "Solid"
         solid = self.makeSolidWith(name=SOLID_LABEL)

--- a/pytissueoptics/scene/tests/solids/testCuboid.py
+++ b/pytissueoptics/scene/tests/solids/testCuboid.py
@@ -40,16 +40,23 @@ class TestCuboid(unittest.TestCase):
         centroid.divide(len(surfacePolygons))
         return centroid
 
-    def testWhenStackOnNonExistentSurface_shouldNotStack(self):
+    def testWhenStackCuboidsWithTheSameLabel_shouldNotStack(self):
         baseCuboid = Cuboid(4, 5, 3)
         otherCuboid = Cuboid(4, 5, 1)
+
+        with self.assertRaises(AssertionError):
+            baseCuboid.stack(otherCuboid, 'front')
+
+    def testWhenStackOnNonExistentSurface_shouldNotStack(self):
+        baseCuboid = Cuboid(4, 5, 3, label="BaseCuboid")
+        otherCuboid = Cuboid(4, 5, 1, label="OtherCuboid")
 
         with self.assertRaises(Exception):
             baseCuboid.stack(otherCuboid, onSurface='BadSurfaceKey')
 
     def testWhenStackUnmatchedSurfaces_shouldNotStack(self):
-        baseCuboid = Cuboid(5, 3, 4)
-        otherCuboid = Cuboid(5, 1, 4)
+        baseCuboid = Cuboid(5, 3, 4, label="BaseCuboid")
+        otherCuboid = Cuboid(5, 1, 4, label="OtherCuboid")
 
         with self.assertRaises(Exception):
             baseCuboid.stack(otherCuboid, onSurface='right')
@@ -57,24 +64,24 @@ class TestCuboid(unittest.TestCase):
     def testWhenStackOnASurface_shouldMoveTheOtherCuboidToBeAdjacentToThisSurface(self):
         basePosition = Vector(2, 2, 1)
         otherPosition = Vector(5, 0, 4)
-        baseCuboid = Cuboid(5, 3, 4, position=basePosition)
-        otherCuboid = Cuboid(5, 1, 4, position=otherPosition)
+        baseCuboid = Cuboid(5, 3, 4, position=basePosition, label="BaseCuboid")
+        otherCuboid = Cuboid(5, 1, 4, position=otherPosition, label="OtherCuboid")
 
         baseCuboid.stack(otherCuboid, onSurface='bottom')
 
         self.assertEqual(baseCuboid.position + Vector(0, -2, 0), otherCuboid.position)
 
     def testWhenStack_shouldShareSurfacesWithTheOtherCuboid(self):
-        baseCuboid = Cuboid(5, 3, 4)
-        otherCuboid = Cuboid(5, 1, 4)
+        baseCuboid = Cuboid(5, 3, 4, label="BaseCuboid")
+        otherCuboid = Cuboid(5, 1, 4, label="OtherCuboid")
 
         baseCuboid.stack(otherCuboid, onSurface='top')
 
         self.assertEqual(baseCuboid.getPolygons('top'), otherCuboid.getPolygons('bottom'))
 
     def testWhenStack_shouldSetOtherCuboidEnvironmentAtInterface(self):
-        baseCuboid = Cuboid(5, 3, 4)
-        otherCuboid = Cuboid(5, 1, 4)
+        baseCuboid = Cuboid(5, 3, 4, label="BaseCuboid")
+        otherCuboid = Cuboid(5, 1, 4, label="OtherCuboid")
         topEnvironment = otherCuboid.getEnvironment()
 
         baseCuboid.stack(otherCuboid, onSurface='top')
@@ -84,8 +91,8 @@ class TestCuboid(unittest.TestCase):
 
     def testWhenStack_shouldReturnANewCuboidMadeOfTheseTwoCuboids(self):
         basePosition = Vector(2, 2, 1)
-        baseCuboid = Cuboid(5, 3, 4, position=basePosition)
-        otherCuboid = Cuboid(5, 1, 4)
+        baseCuboid = Cuboid(5, 3, 4, position=basePosition, label="BaseCuboid")
+        otherCuboid = Cuboid(5, 1, 4, label="OtherCuboid")
 
         cuboidStack = baseCuboid.stack(otherCuboid, onSurface='bottom')
 
@@ -93,8 +100,8 @@ class TestCuboid(unittest.TestCase):
         self.assertEqual(basePosition - Vector(0, 0.5, 0), cuboidStack.position)
 
     def testWhenStack_shouldReturnANewCuboidWithAFirstInterface(self):
-        baseCuboid = Cuboid(5, 3, 4)
-        otherCuboid = Cuboid(5, 1, 4)
+        baseCuboid = Cuboid(5, 3, 4, label="BaseCuboid")
+        otherCuboid = Cuboid(5, 1, 4, label="OtherCuboid")
 
         cuboidStack = baseCuboid.stack(otherCuboid, onSurface='top')
 
@@ -116,12 +123,12 @@ class TestCuboid(unittest.TestCase):
         self.assertEqual(otherCuboid, interfacePolygon.outsideEnvironment.solid)
 
     def testWhenStackAnotherStack_shouldReturnANewCuboidWithAllStackInterfaces(self):
-        baseCuboid1 = Cuboid(5, 3, 4)
-        otherCuboid1 = Cuboid(5, 1, 4)
+        baseCuboid1 = Cuboid(5, 3, 4, label="BaseCuboid1")
+        otherCuboid1 = Cuboid(5, 1, 4, label="OtherCuboid1")
         cuboidStack1 = baseCuboid1.stack(otherCuboid1, onSurface='top')
 
-        baseCuboid2 = Cuboid(2, 4, 4)
-        otherCuboid2 = Cuboid(3, 4, 4)
+        baseCuboid2 = Cuboid(2, 4, 4, label="BaseCuboid2")
+        otherCuboid2 = Cuboid(3, 4, 4, label="OtherCuboid2")
         cuboidStack2 = baseCuboid2.stack(otherCuboid2, onSurface='right')
 
         cuboidStack = cuboidStack1.stack(cuboidStack2, onSurface='right')
@@ -130,12 +137,12 @@ class TestCuboid(unittest.TestCase):
             self.assertTrue(f"{INTERFACE_KEY}{i}" in cuboidStack.surfaceLabels)
 
     def testWhenStackAnotherStackNotAlongTheAlreadyStackedAxis_shouldNotStack(self):
-        baseCuboid1 = Cuboid(5, 3, 4)
-        otherCuboid1 = Cuboid(5, 1, 4)
+        baseCuboid1 = Cuboid(5, 3, 4, label="base1")
+        otherCuboid1 = Cuboid(5, 1, 4, label="other1")
         cuboidStack1 = baseCuboid1.stack(otherCuboid1, onSurface='top')
 
-        baseCuboid2 = Cuboid(2, 4, 4)
-        otherCuboid2 = Cuboid(3, 4, 4)
+        baseCuboid2 = Cuboid(2, 4, 4, label="base2")
+        otherCuboid2 = Cuboid(3, 4, 4, label="other2")
         cuboidStack2 = baseCuboid2.stack(otherCuboid2, onSurface='right')
 
         with self.assertRaises(Exception):

--- a/pytissueoptics/scene/tests/solids/testCylinder.py
+++ b/pytissueoptics/scene/tests/solids/testCylinder.py
@@ -76,3 +76,7 @@ class TestCylinder(unittest.TestCase):
         cylinder = Cylinder(radius=1000, height=3, u=6, position=Vector(0, 0, 0))
         vertices = [Vertex(0, 866, 0)]
         self.assertTrue(cylinder.contains(*vertices))
+
+    def testWhenSmoothWithLessThan16Sides_shouldWarn(self):
+        with self.assertWarns(UserWarning):
+            Cylinder(u=15, smooth=True)

--- a/pytissueoptics/scene/tests/solids/testCylinder.py
+++ b/pytissueoptics/scene/tests/solids/testCylinder.py
@@ -9,6 +9,7 @@ class TestCylinder(unittest.TestCase):
     def testGivenANewDefault_shouldBePlacedAtOrigin(self):
         cylinder = Cylinder()
         self.assertEqual(Vector(0, 0, 0), cylinder.position)
+        self.assertEqual(Vector(0, 0, 0), cylinder.bbox.center)
 
     def testGivenANew_shouldBePlacedAtDesiredPosition(self):
         position = Vector(2, 2, 1)

--- a/pytissueoptics/scene/tests/solids/testEllipsoid.py
+++ b/pytissueoptics/scene/tests/solids/testEllipsoid.py
@@ -73,3 +73,12 @@ class TestEllipsoid(unittest.TestCase):
         vertices = [Vertex(3.4, 2.9, 0), Vertex(2, 2, 0)]
 
         self.assertFalse(ellipsoid.contains(*vertices))
+
+    def testWhenContainsWithVertexCloseToCenter_shouldReturnTrue(self):
+        """ Testing a special case that used to fail because relative vertex radius is smaller than 1."""
+        ellipsoid = Ellipsoid(1, 1, 1)
+        self.assertTrue(ellipsoid.contains(Vertex(0, 0, 0.2)))
+
+    def testWhenContainsWithVertexOnSurface_shouldReturnFalse(self):
+        ellipsoid = Ellipsoid(1, 1, 1)
+        self.assertFalse(ellipsoid.contains(Vertex(0, 0, 1)))

--- a/pytissueoptics/scene/tests/solids/testSolid.py
+++ b/pytissueoptics/scene/tests/solids/testSolid.py
@@ -176,9 +176,21 @@ class TestSolid(unittest.TestCase):
     def testGivenNoSurfaces_whenCreateSolidWithAnotherPrimitive_shouldRaiseException(self):
         self._testGivenNoSurfaces_whenCreateSolidWithAnyPrimitive_shouldRaiseException("anotherPrimitive")
 
-    def testWhenCheckIfContainsAVertex_shouldWarnAndReturnFalse(self):
+    def testWhenCheckIfContainsAVertexOutsideBBox_shouldReturnFalse(self):
+        self.assertFalse(self.solid.contains(Vertex(0, 0, 0)))
+
+    def testWhenCheckIfContainsAVertexInsideInternalBBox_shouldReturnTrue(self):
+        self.assertTrue(self.solid.contains(Vertex(2, 2, 0)))
+
+    def testWhenCheckIfContainsAVertexPartiallyInside_shouldWarnAndReturnFalse(self):
+        otherVertices = [Vertex(1, 1, -0.5), Vertex(3, 1, -0.5), Vertex(3, 3, -0.5), Vertex(1, 3, -0.5)]
+        self.CUBOID_VERTICES.extend(otherVertices)
+        self.CUBOID_SURFACES.add('other', [Quad(*otherVertices)])
+        self.solid = Solid(material=self.material, vertices=self.CUBOID_VERTICES,
+                           surfaces=self.CUBOID_SURFACES, primitive=primitives.TRIANGLE)
+
         with self.assertWarns(RuntimeWarning):
-            self.assertFalse(self.solid.contains(Vertex(0, 0, 0)))
+            self.assertFalse(self.solid.contains(Vertex(2, 2, -0.75)))
 
     @staticmethod
     def createPolygonMock() -> Polygon:

--- a/pytissueoptics/scene/tests/solids/testSolid.py
+++ b/pytissueoptics/scene/tests/solids/testSolid.py
@@ -176,9 +176,9 @@ class TestSolid(unittest.TestCase):
     def testGivenNoSurfaces_whenCreateSolidWithAnotherPrimitive_shouldRaiseException(self):
         self._testGivenNoSurfaces_whenCreateSolidWithAnyPrimitive_shouldRaiseException("anotherPrimitive")
 
-    def testWhenCheckIfContainsAVertex_shouldRaiseException(self):
-        with self.assertRaises(NotImplementedError):
-            self.solid.contains(Vertex(0, 0, 0))
+    def testWhenCheckIfContainsAVertex_shouldWarnAndReturnFalse(self):
+        with self.assertWarns(RuntimeWarning):
+            self.assertFalse(self.solid.contains(Vertex(0, 0, 0)))
 
     @staticmethod
     def createPolygonMock() -> Polygon:

--- a/pytissueoptics/scene/tests/solids/testSolidGroup.py
+++ b/pytissueoptics/scene/tests/solids/testSolidGroup.py
@@ -33,6 +33,6 @@ class TestSolidGroup(unittest.TestCase):
 
         groupSurfaceLabels = solidGroup.surfaceLabels
         self.assertEqual(18, len(groupSurfaceLabels))
-        for expectedCuboidLabel in [CUBOID_LABEL, f"{CUBOID_LABEL}_2", f"{CUBOID_LABEL}_3"]:
+        for expectedCuboidLabel in [CUBOID_LABEL, f"{CUBOID_LABEL}2", f"{CUBOID_LABEL}3"]:
             for surfaceLabel in self.cuboidSurfaceLabels:
                 self.assertIn(f"{expectedCuboidLabel}_{surfaceLabel}", groupSurfaceLabels)

--- a/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
+++ b/pytissueoptics/scene/viewer/mayavi/MayaviViewer.py
@@ -1,5 +1,6 @@
 import numpy as np
 
+from pytissueoptics.scene.geometry import BoundingBox
 from pytissueoptics.scene.logger import Logger
 from pytissueoptics.scene.scene import Scene
 from pytissueoptics.scene.viewer.mayavi.viewPoint import ViewPointStyle, ViewPointFactory
@@ -139,3 +140,9 @@ class MayaviViewer:
 
     def close(self):
         mlab.close()
+
+    def addBBox(self, bbox: BoundingBox, lineWidth=0.25, color=(1, 1, 1), opacity=1.0, **kwargs):
+        """ Adds a bounding box to the scene. """
+        s = mlab.plot3d([bbox.xMin, bbox.xMax], [bbox.yMin, bbox.yMax], [bbox.zMin, bbox.zMax],
+                        tube_radius=None, line_width=0, opacity=0)
+        mlab.outline(s, line_width=lineWidth, color=color, opacity=opacity, **kwargs)


### PR DESCRIPTION
Various bug fixes and minor improvements

## Changes
- Fixed bad statistics report when solid contains another solid with the same surface labels. 
    -  New approach to surface labels: include the solid label in the name. This clears out previous bugs and limitations when working with contained solids that had repeating surface labels.
    - Backcompat user endpoints of show2D and show1D: auto-complete provided surface label if it does not include the solid label. 
- Fix mesh of Cylinder (vertex normals)
- Fix vertex normals of rotated smooth surfaces
- Fix Ellipsoid.contains(vertex)
- Fix source environment when positioned in a contained solid
- Change default position of Cylinder to have its centroid on the origin
- Add default implementation (but very limited) for Solid.contains(vertex). "Abstract" Solid type is used when loading external models.
- Improved OpenCL warnings (preparing for source to be hardware accelerated by default)
- Add MayaviView.addBBox()