### PR TITLE
Fix error when pyopencl is not installed

### DIFF
--- a/pytissueoptics/rayscattering/opencl/buffers/CLObject.py
+++ b/pytissueoptics/rayscattering/opencl/buffers/CLObject.py
@@ -4,7 +4,11 @@ try:
     import pyopencl as cl
     import pyopencl.tools
 except ImportError:
-    pass
+    class DummyType:
+        def __getattr__(self, item):
+            return None
+    cl = DummyType()
+    cl.cltypes = DummyType()
 
 
 class CLObject:
@@ -20,7 +24,7 @@ class CLObject:
         self._HOST_buffer = None
         self._DEVICE_buffer = None
 
-    def build(self, device: 'cl.Device', context):
+    def build(self, device: cl.Device, context):
         if self.deviceBuffer is not None:
             if self._buildOnce:
                 return

--- a/pytissueoptics/rayscattering/opencl/config/CLConfig.py
+++ b/pytissueoptics/rayscattering/opencl/config/CLConfig.py
@@ -6,9 +6,12 @@ from typing import List
 
 try:
     import pyopencl as cl
-
     OPENCL_AVAILABLE = True
 except ImportError:
+    class DummyCL:
+        def __getattr__(self, item):
+            return None
+    cl = DummyCL()
     OPENCL_AVAILABLE = False
 
 warnings.formatwarning = lambda msg, *args, **kwargs: f'{msg}\n'


### PR DESCRIPTION
While this fix is not essential now that pyopencl is in the main requirements file, it can still help to have better error handling over missing imports (see issue #92). 

When pyopencl was not installed, the program crashed because of type hints not being resolved. We now fallback to a dummy class to support this typing. This will make sure the program still runs (on native python implemetation) and the user reaches our warning about pyopencl not being installed. 
