### PR TITLE
Bugfix bbox and statistics

### DIFF
--- a/pytissueoptics/examples/rayscattering/ex03.py
+++ b/pytissueoptics/examples/rayscattering/ex03.py
@@ -14,36 +14,33 @@ At that point you can comment out the line ‘source.propagate()‘ if you don't
 the different views and information the object Stats provides.
 """
 
-# FIXME: does not work with hardware acceleration. Rays are passing through the lens without intersecting it.
-
 
 def exampleCode():
-    # N = 100000 if hardwareAccelerationIsAvailable() else 2000
-    N = 2000
+    N = 100000 if hardwareAccelerationIsAvailable() else 2000
     glassMaterial = ScatteringMaterial(mu_s=0.0, mu_a=0, g=0.7, n=1.34)
     absorptiveMaterial = ScatteringMaterial(mu_s=1.0, mu_a=0.5, g=1.0)
     blockMaterial = ScatteringMaterial(mu_s=1.0, mu_a=10, g=0.7, n=1.0)
+    
+    screen1 = Cuboid(a=4, b=4, c=0.1, position=Vector(0, 0, 3), material=absorptiveMaterial, label="Screen1")
+    screen2 = Cuboid(a=4, b=4, c=0.1, position=Vector(0, 0, 5), material=absorptiveMaterial, label="Screen2")
+    screen3 = Cuboid(a=4, b=4, c=0.1, position=Vector(0, 0, 10), material=blockMaterial, label="Screen3")
 
-    screen1 = Cuboid(a=0.1, b=4, c=4, position=Vector(3, 0, 0), material=absorptiveMaterial, label="Screen1")
-    screen2 = Cuboid(a=0.1, b=4, c=4, position=Vector(5, 0, 0), material=absorptiveMaterial, label="Screen2")
-    screen3 = Cuboid(a=0.1, b=4, c=4, position=Vector(10, 0, 0), material=blockMaterial, label="Screen3")
-
-    ellipsoid = Ellipsoid(a=0.5, b=2, c=2, position=Vector(-1, 0, 0), material=glassMaterial)
+    ellipsoid = Ellipsoid(a=2, b=2, c=0.5, position=Vector(0, 0, -1), material=glassMaterial)
     myCustomScene = ScatteringScene([screen1, screen2, screen3, ellipsoid])
-    logger = EnergyLogger(myCustomScene)
-    source = DirectionalSource(position=Vector(-3, 0, 0), direction=Vector(1, 0, 0), diameter=1, N=N,
-                               useHardwareAcceleration=False, displaySize=0.5)
+    source = DirectionalSource(position=Vector(0, 0, -3), direction=Vector(0, 0, 1), diameter=1, N=N, displaySize=0.5)
+
     myCustomScene.show(source=source)
 
+    logger = EnergyLogger(myCustomScene)
     source.propagate(myCustomScene, logger)
 
     viewer = Viewer(myCustomScene, source, logger)
     viewer.reportStats()
 
     viewer.show3D()
-    viewer.show2D(View2DProjectionX("Screen1"), logScale=False)
-    viewer.show2D(View2DSurfaceX("Screen2", "left", surfaceEnergyLeaving=False), logScale=False)
-    viewer.show2D(View2DProjectionX("Screen3"))
+    viewer.show2D(View2DProjectionZ("Screen1"), logScale=False)
+    viewer.show2D(View2DSurfaceZ("Screen2", "front", surfaceEnergyLeaving=False), logScale=False)
+    viewer.show2D(View2DProjectionZ("Screen3"))
 
 
 if __name__ == "__main__":

--- a/pytissueoptics/rayscattering/fresnel.py
+++ b/pytissueoptics/rayscattering/fresnel.py
@@ -39,7 +39,9 @@ class FresnelIntersect:
             incidencePlane = rayDirection.getAnyOrthogonal()
         incidencePlane.normalize()
 
-        self._thetaIn = math.acos(normal.dot(rayDirection))
+        dot = normal.dot(rayDirection)
+        dot = max(min(dot, 1), -1)
+        self._thetaIn = math.acos(dot)
 
         return self._create(nextEnvironment, incidencePlane)
 

--- a/pytissueoptics/rayscattering/opencl/CLScene.py
+++ b/pytissueoptics/rayscattering/opencl/CLScene.py
@@ -88,7 +88,10 @@ class CLScene:
         if surfaceID not in self._surfaceLabels[solidID]:
             self._surfaceLabels[solidID][surfaceID] = surfaceLabel
         if outsideSolid is not None:
-            self._surfaceLabels[self.getSolidID(outsideSolid)][surfaceID] = surfaceLabel
+            outsideSolidID = self.getSolidID(outsideSolid)
+            if outsideSolidID not in self._surfaceLabels:
+                self._surfaceLabels[outsideSolidID] = {}
+            self._surfaceLabels[outsideSolidID][surfaceID] = surfaceLabel
 
     def _compileSurface(self, polygonRef, firstPolygonID, lastPolygonID):
         insideEnvironment = polygonRef.insideEnvironment
@@ -130,7 +133,8 @@ class CLScene:
 
             vertexIDs = [vertexToID[id(v)] for v in triangle.vertices]
             self._trianglesInfo.append(TriangleCLInfo(vertexIDs, triangle.normal))
-            self._processPolygon(triangle, surfaceLabel, surfaceID=len(self._surfacesInfo))
+            newSurfaceID = len(self._surfacesInfo)
+            self._processPolygon(triangle, surfaceLabel, surfaceID=newSurfaceID)
             lastSolid = currentSolid
 
         self._compileSurface(polygonRef=polygons[-1],

--- a/pytissueoptics/rayscattering/opencl/src/fresnel.c
+++ b/pytissueoptics/rayscattering/opencl/src/fresnel.c
@@ -95,7 +95,7 @@ FresnelIntersection computeFresnelIntersection(float3 rayDirection, Intersection
     }
     fresnelIntersection.incidencePlane = normalize(fresnelIntersection.incidencePlane);
 
-    float thetaIn = acos(dot(normal, rayDirection));
+    float thetaIn = acos(clamp(dot(normal, rayDirection), -1.0f, 1.0f));
 
     _createFresnelIntersection(&fresnelIntersection, nIn, nOut, thetaIn, seeds, gid);
 

--- a/pytissueoptics/rayscattering/statistics/statistics.py
+++ b/pytissueoptics/rayscattering/statistics/statistics.py
@@ -162,7 +162,7 @@ class Stats:
         for surfaceLabel in self._logger.getSeenSurfaceLabels(solidLabel):
             energy += self._getSurfaceEnergyFromViews(solidLabel, surfaceLabel, leaving=leaving)
 
-        if utils.labelsEqual(self._sourceSolidLabel, solidLabel):
+        if utils.labelsEqual(self._sourceSolidLabel, solidLabel) and not leaving:
             energy += self.getPhotonCount()
         return energy
 

--- a/pytissueoptics/scene/geometry/rotation.py
+++ b/pytissueoptics/scene/geometry/rotation.py
@@ -33,7 +33,9 @@ class Rotation:
         """ Create the euler rotation needed to go from one orientation to another. """
         fromDirection.normalize()
         toDirection.normalize()
-        angle = np.arccos(fromDirection.dot(toDirection))
+        dot = fromDirection.dot(toDirection)
+        dot = max(min(dot, 1), -1)
+        angle = np.arccos(dot)
         axis = fromDirection.cross(toDirection)
         axis.normalize()
         axis = axis.array

--- a/pytissueoptics/scene/scene/scene.py
+++ b/pytissueoptics/scene/scene/scene.py
@@ -155,7 +155,7 @@ class Scene(Displayable):
         if len(self._solids) == 0:
             return None
 
-        bbox = self._solids[0].getBoundingBox()
+        bbox = self._solids[0].getBoundingBox().copy()
         for solid in self._solids[1:]:
             bbox.extendTo(solid.getBoundingBox())
         return bbox


### PR DESCRIPTION
- Fixed energy input statistics calculated from 2D views when 3D data is discarded.
- Fixed solid bbox getting corrupted when scene limits were defined. 
- Fixed floating point error crash in python implementation. Limit unit dot product between -1 and 1.