### PR TITLE
Fix infinite refractions

### DIFF
--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -235,38 +235,48 @@ Intersection _findClosestPolygonIntersection(Ray ray, uint solidID,
 float _cotangent(float3 v0, float3 v1, float3 v2) {
     float3 edge0 = v0 - v1;
     float3 edge1 = v2 - v1;
-    return dot(edge1, edge0) / length(cross(edge1, edge0));
+    float lengthCross = length(cross(edge1, edge0));
+    if (lengthCross < EPS_SIDE) {
+        lengthCross = EPS_SIDE;
+    }
+    return dot(edge1, edge0) / lengthCross;
 }
 
 void setSmoothNormal(Intersection *intersection, __global Triangle *triangles, __global Vertex *vertices, Ray *ray) {
-    
+    float3 newNormal;
+    bool newNormalSet = false;
+
     // Check edge case where the intersection is directly on a vertex, in which case we just return the vertex normal.
     for (uint i = 0; i < 3; i++) {
         float3 vertex = vertices[triangles[intersection->polygonID].vertexIDs[i]].position;
         if (length(intersection->position - vertex) < EPS_SIDE) {
-            intersection->normal = vertices[triangles[intersection->polygonID].vertexIDs[i]].normal;
-            return;
+            newNormal = vertices[triangles[intersection->polygonID].vertexIDs[i]].normal;
+            newNormalSet = true;
+            break;
         }
     }
     
-    // Compute the new smooth normal as a weighted average of the vertex normals.
-    float weights[3];
-    for (uint i = 0; i < 3; i++) {
-        float3 vertex = vertices[triangles[intersection->polygonID].vertexIDs[i]].position;
-        float3 prevVertex = vertices[triangles[intersection->polygonID].vertexIDs[(i + 2) % 3]].position;
-        float3 nextVertex = vertices[triangles[intersection->polygonID].vertexIDs[(i + 1) % 3]].position;
-        float cotPrev = _cotangent(intersection->position, vertex, prevVertex);
-        float cotNext = _cotangent(intersection->position, vertex, nextVertex);
-        float d = length(vertex - intersection->position);
-        weights[i] = (cotPrev + cotNext) / (d * d);
+    if (!newNormalSet) {
+        // Compute the new smooth normal as a weighted average of the vertex normals.
+        float weights[3];
+        for (uint i = 0; i < 3; i++) {
+            float3 vertex = vertices[triangles[intersection->polygonID].vertexIDs[i]].position;
+            float3 prevVertex = vertices[triangles[intersection->polygonID].vertexIDs[(i + 2) % 3]].position;
+            float3 nextVertex = vertices[triangles[intersection->polygonID].vertexIDs[(i + 1) % 3]].position;
+            float cotPrev = _cotangent(intersection->position, vertex, prevVertex);
+            float cotNext = _cotangent(intersection->position, vertex, nextVertex);
+            float d = length(vertex - intersection->position);
+            weights[i] = (cotPrev + cotNext) / (d * d);
+        }
+        printf("weights: %f %f %f\n", weights[0], weights[1], weights[2]);
+        float sum = weights[0] + weights[1] + weights[2];
+        for (uint i = 0; i < 3; i++) {
+            weights[i] /= sum;
+        }
+        newNormal = weights[0] * vertices[triangles[intersection->polygonID].vertexIDs[0]].normal +
+                    weights[1] * vertices[triangles[intersection->polygonID].vertexIDs[1]].normal +
+                    weights[2] * vertices[triangles[intersection->polygonID].vertexIDs[2]].normal;
     }
-    float sum = weights[0] + weights[1] + weights[2];
-    for (uint i = 0; i < 3; i++) {
-        weights[i] /= sum;
-    }
-    float3 newNormal = weights[0] * vertices[triangles[intersection->polygonID].vertexIDs[0]].normal +
-                        weights[1] * vertices[triangles[intersection->polygonID].vertexIDs[1]].normal +
-                        weights[2] * vertices[triangles[intersection->polygonID].vertexIDs[2]].normal;
 
     // Do not allow the new smooth normal to have a different dot product with ray direction. 
     // This is a rare edge case that can happen when the ray direction is approximately parallel to the surface. More comon in low resolution meshes (like icosphere of order 1)
@@ -335,4 +345,10 @@ __kernel void findIntersections(__global Ray *rays, uint nSolids, __global Solid
     uint gid = get_global_id(0);
     Scene scene = {nSolids, solids, surfaces, triangles, vertices, solidCandidates};
     intersections[gid] = findIntersection(rays[gid], &scene, gid);
+}
+
+
+__kernel void setSmoothNormals(__global Intersection *intersections, __global Triangle *triangles, __global Vertex *vertices, __global Ray *rays) {
+    uint gid = get_global_id(0);
+    setSmoothNormal(&intersections[gid], triangles, vertices, &rays[gid]);
 }

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -268,11 +268,12 @@ void setSmoothNormal(Intersection *intersection, __global Triangle *triangles, _
             float d = length(vertex - intersection->position);
             weights[i] = (cotPrev + cotNext) / (d * d);
         }
-        printf("weights: %f %f %f\n", weights[0], weights[1], weights[2]);
+
         float sum = weights[0] + weights[1] + weights[2];
         for (uint i = 0; i < 3; i++) {
             weights[i] /= sum;
         }
+
         newNormal = weights[0] * vertices[triangles[intersection->polygonID].vertexIDs[0]].normal +
                     weights[1] * vertices[triangles[intersection->polygonID].vertexIDs[1]].normal +
                     weights[2] * vertices[triangles[intersection->polygonID].vertexIDs[2]].normal;

--- a/pytissueoptics/rayscattering/tests/opencl/src/testCLSmoothing.py
+++ b/pytissueoptics/rayscattering/tests/opencl/src/testCLSmoothing.py
@@ -1,0 +1,92 @@
+import os
+import traceback
+import unittest
+
+import numpy as np
+
+from pytissueoptics import *
+from pytissueoptics.rayscattering.opencl import OPENCL_AVAILABLE
+from pytissueoptics.rayscattering.opencl.buffers import *
+from pytissueoptics.rayscattering.opencl.config.CLConfig import OPENCL_SOURCE_DIR
+from pytissueoptics.rayscattering.tests.opencl.src.testCLIntersection import RayCL, IntersectionCL
+from pytissueoptics.scene.geometry.triangle import Triangle
+from pytissueoptics.scene.geometry.vertex import Vertex
+from pytissueoptics.rayscattering.opencl.CLProgram import CLProgram
+
+
+@unittest.skipIf(not OPENCL_AVAILABLE, 'Requires PyOpenCL.')
+class TestCLNormalSmoothing(unittest.TestCase):
+    def setUp(self):
+        sourcePath = os.path.join(OPENCL_SOURCE_DIR, "intersection.c")
+        self.program = CLProgram(sourcePath)
+        self._addMissingDeclarations()
+
+        self.VERTICES = [Vertex(0, 0, 0), Vertex(1, 0, 0), Vertex(1, 1, 0)]
+        self.NORMALS = [Vector(-1, -1, 1), Vector(1, -1, 1), Vector(1, 1, 1)]
+        for vertex, normal in zip(self.VERTICES, self.NORMALS):
+            normal.normalize()
+            vertex.normal = normal
+        self.TRIANGLE = Triangle(*self.VERTICES)
+
+    def testShouldInterpolateNormalOfVerticesAtIntersectionPosition(self):
+        position = Vector(0.75, 0.25, 0)
+
+        smoothNormal = self._getSmoothNormal(position)
+
+        expectedNormal = self.NORMALS[0] + self.NORMALS[1] * 2 + self.NORMALS[2]
+        expectedNormal.normalize()
+        self.assertEqual(smoothNormal, expectedNormal)
+
+    def testGivenPositionOnVertexShouldReturnVertexNormal(self):
+        position = self.VERTICES[0]
+
+        smoothNormal = self._getSmoothNormal(position)
+
+        self.assertEqual(smoothNormal, self.NORMALS[0])
+
+    def testGivenPositionOnEdgeShouldInterpolateBetweenEdgeVertices(self):
+        position = Vector(0.5, 0.5, 0)
+
+        smoothNormal = self._getSmoothNormal(position)
+
+        expectedNormal = self.NORMALS[0] + self.NORMALS[2]
+        expectedNormal.normalize()
+        self.assertEqual(smoothNormal, expectedNormal)
+
+    def testShouldNotSmoothIfItChangesTheSignOfTheDotProductWithTheRayDirection(self):
+        position = Vector(1, 1, 0)
+        rayDirection = Vector(1, 0, -0.9)
+        rayDirection.normalize()
+
+        smoothNormal = self._getSmoothNormal(position, rayDirection)
+
+        self.assertEqual(smoothNormal, self.TRIANGLE.normal)
+
+    def _getSmoothNormal(self, atPosition: Vector, rayDirection: Vector = Vector(0, 0, 1)) -> Vector:
+        verticesCL = VertexCL(self.VERTICES)
+        triangleInfo = TriangleCLInfo([0, 1, 2], self.TRIANGLE.normal)
+        triangleCL = TriangleCL([triangleInfo])
+        N = 1
+        intersectionCL = IntersectionCL(N)
+        intersectionCL.setResults(np.full(N, 0), np.full((N, 3), atPosition.array), np.full((N, 3), self.TRIANGLE.normal.array))
+        rayCL = RayCL(origins=np.full((N, 3), [0, 0, 0]),
+                      directions=np.full((N, 3), rayDirection.array),
+                      lengths=np.full(N, 10))
+
+        try:
+            self.program.launchKernel("setSmoothNormals", N=N, arguments=[intersectionCL, triangleCL, verticesCL, rayCL])
+        except Exception as e:
+            traceback.print_exc(0)
+
+        self.program.getData(intersectionCL)
+        smoothNormal = intersectionCL.hostBuffer[0]["normal"]
+        return Vector(smoothNormal["x"], smoothNormal["y"], smoothNormal["z"])
+
+    def _addMissingDeclarations(self):
+        self.program._include = ''
+        missingObjects = [MaterialCL([ScatteringMaterial()]), SurfaceCL([]), SeedCL(1),
+                           DataPointCL(1), SolidCandidateCL(1, 1), SolidCL([])]
+
+        for clObject in missingObjects:
+            clObject.make(self.program.device)
+            self.program.include(clObject.declaration)

--- a/pytissueoptics/scene/intersection/intersectionFinder.py
+++ b/pytissueoptics/scene/intersection/intersectionFinder.py
@@ -55,7 +55,13 @@ class IntersectionFinder:
         if not intersection:
             return None
 
-        intersection.normal = shader.getSmoothNormal(intersection.polygon, intersection.position)
+        smoothNormal = shader.getSmoothNormal(intersection.polygon, intersection.position)
+
+        # If the resulting smooth normal changes the sign of the dot product with the ray direction, do not smooth.
+        if smoothNormal.dot(ray.direction) * intersection.polygon.normal.dot(ray.direction) < 0:
+            smoothNormal = intersection.polygon.normal
+
+        intersection.normal = smoothNormal
         intersection.insideEnvironment = intersection.polygon.insideEnvironment
         intersection.outsideEnvironment = intersection.polygon.outsideEnvironment
         intersection.surfaceLabel = intersection.polygon.surfaceLabel

--- a/pytissueoptics/scene/shader/utils.py
+++ b/pytissueoptics/scene/shader/utils.py
@@ -10,6 +10,11 @@ def getSmoothNormal(polygon: Polygon, position: Vector) -> Vector:
     coordinates algorithm from http://www.geometry.caltech.edu/pubs/MHBD02.pdfv. """
     if not polygon.toSmooth:
         return polygon.normal
+    
+    # Check edge case where the intersection is directly on a vertex, in which case we just return the vertex normal.
+    for vertex in polygon.vertices:
+        if (position - vertex).getNorm() < 1e-6:
+            return vertex.normal
 
     weights = _getBarycentricWeights(polygon.vertices, position)
 
@@ -37,4 +42,7 @@ def _cotangent(a: Vector, b: Vector, c: Vector) -> float:
     """ Cotangent of triangle abc at vertex b. """
     ba = a - b
     bc = c - b
-    return bc.dot(ba) / bc.cross(ba).getNorm()
+    norm = ba.cross(bc).getNorm()
+    if norm < 1e-6:
+        norm = 1e-6
+    return bc.dot(ba) / norm

--- a/pytissueoptics/scene/tests/intersection/testIntersectionFinder.py
+++ b/pytissueoptics/scene/tests/intersection/testIntersectionFinder.py
@@ -178,6 +178,28 @@ class TestAnyIntersectionFinder:
 
         self.assertIsNone(intersection)
 
+    def testGivenSmoothSolid_shouldSmoothTheIntersectionNormal(self):
+        ray = Ray(origin=Vector(0, 0.7, -3), direction=Vector(0, 0, 1))
+        solid = Sphere(radius=1, order=1)
+
+        intersection = self.getIntersectionFinder([solid]).findIntersection(ray)
+
+        expectedAngle = math.atan(intersection.position.y / intersection.position.z)
+        expectedNormal = Vector(0, -math.sin(expectedAngle), -math.cos(expectedAngle))
+        self.assertIsNotNone(intersection)
+        self.assertEqual(expectedNormal, intersection.normal)
+
+    def testGivenSmoothSolid_shouldNotSmoothTheIntersectionNormalIfItChangesTheSignOfTheDotProductWithTheRayDirection(self):
+        ray = Ray(origin=Vector(0, 0.955, -2), direction=Vector(0, 0.02, 1))
+        solid = Sphere(radius=1, order=1)
+
+        intersection = self.getIntersectionFinder([solid]).findIntersection(ray)
+
+        smoothAngle = math.atan(intersection.position.y / intersection.position.z)
+        smoothNormal = Vector(0, -math.sin(smoothAngle), -math.cos(smoothAngle))
+        self.assertIsNotNone(intersection)
+        self.assertNotEqual(smoothNormal, intersection.normal)
+
     def assertVectorEqual(self, expected, actual):
         self.assertEqual(expected.x, actual.x)
         self.assertEqual(expected.y, actual.y)

--- a/pytissueoptics/scene/tests/shader/testSmoothing.py
+++ b/pytissueoptics/scene/tests/shader/testSmoothing.py
@@ -7,6 +7,7 @@ from pytissueoptics.scene.shader import getSmoothNormal
 
 class TestSmoothing(unittest.TestCase):
     def setUp(self):
+        # Create a XY square polygon with normals pointing outwards along the Z axis.
         vertices = [Vertex(0, 0, 0), Vertex(1, 0, 0),
                     Vertex(1, 1, 0), Vertex(0, 1, 0)]
         normals = [Vector(-1, -1, 1), Vector(1, -1, 1),
@@ -15,7 +16,7 @@ class TestSmoothing(unittest.TestCase):
             normals[i].normalize()
             vertices[i].normal = normals[i]
 
-        self.initialNormal = Vector(0, 0, -1)
+        self.initialNormal = Vector(0, 0, 1)
         self.polygon = Polygon(vertices=vertices, normal=self.initialNormal)
         self.polygon.toSmooth = True
 
@@ -29,12 +30,14 @@ class TestSmoothing(unittest.TestCase):
         smoothNormal = getSmoothNormal(self.polygon, Vector(0.2, 0.2, 0))
         self.assertEqual(self.initialNormal, smoothNormal)
 
-    def testGivenPositionOnSideOfPolygon_shouldRaiseZeroDivisionError(self):
-        position = Vector(0.5, 1, 0)
-        with self.assertRaises(ZeroDivisionError):
-            getSmoothNormal(self.polygon, position)
+    def testGivenPositionOnSideOfPolygon_shouldReturnInterpolatedNormalBetweenSideVertices(self):
+        position = Vector(0.5, 0, 0)
+        smoothNormal = getSmoothNormal(self.polygon, position)
+        expectedNormal = Vector(0, -1, 1)
+        expectedNormal.normalize()
+        self.assertEqual(expectedNormal, smoothNormal)
 
-    def testGivenPositionOutsidePolygon_shouldRaiseZeroDivisionError(self):
-        position = Vector(-1, 0, 0)
-        with self.assertRaises(ZeroDivisionError):
-            getSmoothNormal(self.polygon, position)
+    def testGivenPositionOnVertex_shouldReturnVertexNormal(self):
+        position = Vector(0, 0, 0)
+        smoothNormal = getSmoothNormal(self.polygon, position)
+        self.assertEqual(self.polygon.vertices[0].normal, smoothNormal)


### PR DESCRIPTION
Do not smooth the normal if it is going to change the dot product with the ray. This lead to wrong next environment being set by FresnelIntersection as well as the wrong step correction applied. 

This issue was initially found by using a sphere that has a refractive index equal to the outside medium. Since the photons were refracting with no angle change, and the wrong step correction was applied, the photons were stuck inside "banging their head against the wall" while slowly surfing the sphere surface. Example of this issue:

![image](https://github.com/DCC-Lab/PyTissueOptics/assets/29587649/36b98ecb-7337-45e7-8a3e-462fe90247a6)
