### PR TITLE
Support to put solids inside stack layers

### DIFF
--- a/pytissueoptics/scene/solids/cuboid.py
+++ b/pytissueoptics/scene/solids/cuboid.py
@@ -107,7 +107,8 @@ class Cuboid(Solid):
             bbox = self._getLayerBBox(layerLabel)
             bboxShape = [bbox.xWidth, bbox.yWidth, bbox.zWidth]
             bounds = [s/2 for s in bboxShape]
-            layerRelativeVertices = relativeVertices - bbox.center.array
+            layerOffset = bbox.center - self.position
+            layerRelativeVertices = relativeVertices - np.asarray(layerOffset.array)
             if np.all(np.abs(layerRelativeVertices) < bounds):
                 return True
         return False

--- a/pytissueoptics/scene/solids/cuboid.py
+++ b/pytissueoptics/scene/solids/cuboid.py
@@ -2,8 +2,7 @@ from typing import List
 
 import numpy as np
 
-from pytissueoptics.scene.geometry import Vector, Quad, Triangle, utils, Vertex
-from pytissueoptics.scene.geometry import primitives
+from pytissueoptics.scene.geometry import Vector, Quad, Triangle, utils, Vertex, BoundingBox, Polygon, primitives
 from pytissueoptics.scene.solids import Solid
 from pytissueoptics.scene.geometry import SurfaceCollection
 from pytissueoptics.scene.solids.stack.cuboidStacker import CuboidStacker
@@ -92,4 +91,35 @@ class Cuboid(Solid):
         bounds = [s/2 for s in self.shape]
         if np.any(np.abs(relativeVertices) >= bounds):
             return False
+
+        if vertices.shape[0] == 1:
+            # No need to check possible stack layers since a single vertex will always be perfectly contained in one of them.
+            return True
+
+        if self.isStack():
+            # At this point, all vertices are contained in the bounding box of the stack.
+            # We just need to make sure they are contained in a single layer.
+            return self._aSingleLayerContains(relativeVertices)
         return True
+
+    def _aSingleLayerContains(self, relativeVertices: np.ndarray) -> bool:
+        for layerLabel in self._layerLabels:
+            bbox = self._getLayerBBox(layerLabel)
+            bboxShape = [bbox.xWidth, bbox.yWidth, bbox.zWidth]
+            bounds = [s/2 for s in bboxShape]
+            layerRelativeVertices = relativeVertices - bbox.center.array
+            if np.all(np.abs(layerRelativeVertices) < bounds):
+                return True
+        return False
+
+    def _getLayerBBox(self, layerLabel: str) -> BoundingBox:
+        polygons = self._getLayerPolygons(layerLabel)
+        bbox = BoundingBox.fromPolygons(polygons)
+        return bbox
+
+    def _getLayerPolygons(self, layerLabel: str) -> List[Polygon]:
+        layerSurfaceLabels = self._layerLabels[layerLabel]
+        polygons = []
+        for surfaceLabel in layerSurfaceLabels:
+            polygons.extend(self._surfaces.getPolygons(surfaceLabel))
+        return polygons

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -190,6 +190,11 @@ class Solid:
         raise NotImplementedError(f"Quad mesh not implemented for Solids of type {type(self).__name__}")
 
     def contains(self, *vertices: Vector) -> bool:
+        """
+        Provides a simple implementation, which should be overwritten by subclasses to provide more accuracy.
+        This implementation will only check the outer bounding box of the solid to check if the vertices are outside. 
+        Similarly, it will create a max internal bounding box and check if the vertices are inside. 
+        """
         for vertex in vertices:
             if not self._bbox.contains(vertex):
                 return False


### PR DESCRIPTION
Allow to add solids in a scene when the solid is fully contained inside a sub layer of a stack. This automatically computes and set the proper outside environment for the contained solid.