### PR TITLE
Fix cylinder.contains()

### DIFF
--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -26,7 +26,9 @@ class Cylinder(Solid):
 
     @property
     def direction(self) -> Vector:
-        return self._topCenter - self._bottomCenter
+        direction = self._topCenter - self._bottomCenter
+        direction.normalize()
+        return direction
 
     def _computeTriangleMesh(self):
         verticesGroups = self._computeVertices()
@@ -86,19 +88,18 @@ class Cylinder(Solid):
         raise NotImplementedError("Quad mesh not implemented for Cylinder")
 
     def contains(self, *vertices: Vector) -> bool:
+        direction = self.direction
+        basePosition = self._position - direction * self._height / 2
         for vertex in vertices:
-            direction = self.direction
-            direction.normalize()
-            localPoint = vertex - self._position
+            localPoint = vertex - basePosition
             alongCylinder = direction.dot(localPoint)
             if alongCylinder < 0 or alongCylinder > self._height:
                 return False
-            else:
-                radiusCheck = self._minRadiusAtHeightAlong(alongCylinder)
-                radialComponent = localPoint - direction * alongCylinder
-                radialDistanceFromBase = radialComponent.getNorm()
-                if radialDistanceFromBase > radiusCheck:
-                    return False
+            radiusCheck = self._minRadiusAtHeightAlong(alongCylinder)
+            radialComponent = localPoint - direction * alongCylinder
+            radialDistanceFromBase = radialComponent.getNorm()
+            if radialDistanceFromBase > radiusCheck:
+                return False
 
         return True
 

--- a/pytissueoptics/scene/tests/solids/testCone.py
+++ b/pytissueoptics/scene/tests/solids/testCone.py
@@ -6,16 +6,29 @@ from pytissueoptics.scene.solids import Cone
 
 class TestCone(unittest.TestCase):
     def testWhenContainsWithVerticesThatAreAllInsideTheCone_shouldReturnTrue(self):
-        cylinder = Cone(radius=1, height=3, u=32, v=2, position=Vector(0, 0, 0))
-        vertices = [Vertex(0, 0, 1), Vertex(0, 0.49, 1.5)]
-        result = cylinder.contains(*vertices)
-        self.assertTrue(result)
+        r = 1
+        h = 3
+        midRadius = r * 0.5
+        f = 0.9
+        cylinder = Cone(radius=r, height=h, u=32, v=2, position=Vector(0, 0, 0))
+        
+        vertices = [Vertex(f*midRadius, 0, 0), Vertex(0, f*midRadius, 0), Vertex(-f*midRadius, 0, 0), Vertex(0, -f*midRadius, 0), 
+                    Vertex(0, 0, f*h*0.5), Vertex(0, 0, -f*h*0.5)]
+        
+        self.assertTrue(cylinder.contains(*vertices))
 
-    def testWhenContainsWithVerticesThatAreNotAllInsideTheCone_shouldReturnFalse(self):
-        cylinder = Cone(radius=1, height=3, u=32, v=2, position=Vector(0, 0, 0))
-        vertices = [Vertex(0, 0, 1), Vertex(0, 0.50, 1.5)]
-        result = cylinder.contains(*vertices)
-        self.assertFalse(result)
+    def testWhenContainsWithVerticesThatAreNotInsideTheCone_shouldReturnFalse(self):
+        r = 1
+        h = 3
+        midRadius = r * 0.5
+        f = 1.1
+        cylinder = Cone(radius=r, height=h, u=32, v=2, position=Vector(0, 0, 0))
+        
+        vertices = [Vertex(f*midRadius, 0, 0), Vertex(0, f*midRadius, 0), Vertex(-f*midRadius, 0, 0), Vertex(0, -f*midRadius, 0), 
+                    Vertex(0, 0, f*h*0.5), Vertex(0, 0, -f*h*0.5)]
+        
+        for vertex in vertices:
+            self.assertFalse(cylinder.contains(vertex))
 
     def testGivenANewWithQuadPrimitive_shouldNotCreateCone(self):
         with self.assertRaises(NotImplementedError):

--- a/pytissueoptics/scene/tests/solids/testCylinder.py
+++ b/pytissueoptics/scene/tests/solids/testCylinder.py
@@ -68,13 +68,28 @@ class TestCylinder(unittest.TestCase):
         self.assertFalse(cylinder.contains(*vertices))
 
     def testWhenContainsWithVerticesOutsideMinRadius_shouldReturnFalse(self):
-        cylinder = Cylinder(radius=1000, height=3, u=6, position=Vector(0, 0, 0))
-        vertices = [Vertex(0, 867, 0)]
-        self.assertFalse(cylinder.contains(*vertices))
+        r = 1000
+        h = 3
+        minRadiusWith6Divisions = 0.866
+        f = minRadiusWith6Divisions * 1.01
+        cylinder = Cylinder(radius=r, height=h, u=6, position=Vector(0, 0, 0))
+        
+        vertices = [Vertex(f * r, 0, 0), Vertex(0, f * r, 0), Vertex(0, 0, h * 0.51),
+                    Vertex(-f * r, 0, 0), Vertex(0, -f * r, 0), Vertex(0, 0, -h * 0.51)]
+        
+        for vertex in vertices:
+            self.assertFalse(cylinder.contains(vertex))
 
     def testWhenContainsWithVerticesInsideMinRadius_shouldReturnTrue(self):
-        cylinder = Cylinder(radius=1000, height=3, u=6, position=Vector(0, 0, 0))
-        vertices = [Vertex(0, 866, 0)]
+        r = 1000
+        h = 3
+        minRadiusWith6Divisions = 0.866
+        f = minRadiusWith6Divisions * 0.99
+        cylinder = Cylinder(radius=r, height=h, u=6, position=Vector(0, 0, 0))
+        
+        vertices = [Vertex(f * r, 0, 0), Vertex(0, f * r, 0), Vertex(0, 0, h * 0.49),
+                    Vertex(-f * r, 0, 0), Vertex(0, -f * r, 0), Vertex(0, 0, -h * 0.49)]
+
         self.assertTrue(cylinder.contains(*vertices))
 
     def testWhenSmoothWithLessThan16Sides_shouldWarn(self):


### PR DESCRIPTION
The algo expected an old cylinder definition where its position was considered at the base. Updated to account for the position now set at center height.