### PR TITLE
Speedup batching

### DIFF
--- a/pytissueoptics/rayscattering/opencl/CLPhotons.py
+++ b/pytissueoptics/rayscattering/opencl/CLPhotons.py
@@ -77,20 +77,26 @@ class CLPhotons:
             params.maxPhotonsPerBatch = kernelPhotons.length
             batchCount += 1
 
-    def _replaceFullyPropagatedPhotons(self, kernelPhotons: PhotonCL, photonPool: PhotonCL,
-                                       photonCount: int, currentKernelLength: int) -> (int, int):
-        photonsToRemove = []
-        batchPhotonCount = 0
-        for i in range(currentKernelLength):
-            if kernelPhotons.hostBuffer[i]["weight"] == 0:
-                newPhotonsRemaining = photonCount + currentKernelLength < self._N
-                if newPhotonsRemaining:
-                    kernelPhotons.hostBuffer[i] = photonPool.hostBuffer[photonCount]
-                else:
-                    photonsToRemove.append(i)
-                photonCount += 1
-                batchPhotonCount += 1
+    def _replaceFullyPropagatedPhotons(self, kernelPhotons: PhotonCL, photonPool: PhotonCL, photonCount: int,
+                                       currentKernelLength: int) -> (int, int):
+        photonsToReplace = np.where(kernelPhotons.hostBuffer["weight"] == 0)[0]
+        batchPhotonCount = len(photonsToReplace)
+
+        if batchPhotonCount == 0:
+            return batchPhotonCount, photonCount
+
+        newPhotonsRemaining = photonCount + currentKernelLength < self._N
+        if newPhotonsRemaining:
+            replacement_photons = photonPool.hostBuffer[photonCount:photonCount + batchPhotonCount]
+            photonsToRemove = photonsToReplace[len(replacement_photons):]
+            photonsToReplace = photonsToReplace[:len(replacement_photons)]
+            kernelPhotons.hostBuffer[photonsToReplace] = replacement_photons
+        else:
+            photonsToRemove = photonsToReplace
+
         kernelPhotons.hostBuffer = np.delete(kernelPhotons.hostBuffer, photonsToRemove)
+
+        photonCount += batchPhotonCount
         return batchPhotonCount, photonCount
 
     def _translateToSceneLogger(self, log, sceneCL, verbose: bool = False):

--- a/pytissueoptics/rayscattering/opencl/CLPhotons.py
+++ b/pytissueoptics/rayscattering/opencl/CLPhotons.py
@@ -69,7 +69,7 @@ class CLPhotons:
             self._translateToSceneLogger(log, scene)
 
             logger.reset()
-            program.getData(kernelPhotons)
+            program.getData(kernelPhotons, returnData=False)
             batchPhotonCount, photonCount = self._replaceFullyPropagatedPhotons(kernelPhotons, photonPool,
                                                                                 photonCount, params.maxPhotonsPerBatch)
 

--- a/pytissueoptics/rayscattering/opencl/CLProgram.py
+++ b/pytissueoptics/rayscattering/opencl/CLProgram.py
@@ -63,8 +63,10 @@ class CLProgram:
 
         self._program = cl.Program(self._context, sourceCode).build()
 
-    def getData(self, _object: CLObject, dtype: np.dtype = np.float32):
+    def getData(self, _object: CLObject, dtype: np.dtype = np.float32, returnData: bool = True):
         cl.enqueue_copy(self._mainQueue, dest=_object.hostBuffer, src=_object.deviceBuffer)
+        if not returnData:
+            return
         if _object.STRUCT_DTYPE is not None:
             return rfn.structured_to_unstructured(_object.hostBuffer, dtype=dtype)
         else:

--- a/pytissueoptics/rayscattering/opencl/utils/CLKeyLog.py
+++ b/pytissueoptics/rayscattering/opencl/utils/CLKeyLog.py
@@ -1,4 +1,5 @@
 from multiprocessing.pool import ThreadPool
+from typing import List
 
 import numpy as np
 
@@ -58,8 +59,7 @@ class CLKeyLog:
 
     def _sortBatch(self, startIdx: int):
         ba, bb = startIdx, startIdx + self._batchSize
-        batchLog = self._log[ba:bb]
-        batchLog = self._sort(batchLog, column=SOLID_ID_COL)
+        batchLog = self._sort(self._log[ba:bb], columns=[SOLID_ID_COL, SURFACE_ID_COL])
 
         solidChanges = self._getValueChangeIndices(batchLog, column=SOLID_ID_COL)
 
@@ -70,7 +70,6 @@ class CLKeyLog:
                 continue
             a, b = solidChanges[i], solidChanges[i + 1]
             batchSolidLog = batchLog[a:b]
-            batchSolidLog = self._sort(batchSolidLog, column=SURFACE_ID_COL)
 
             surfaceChanges = self._getValueChangeIndices(batchSolidLog, column=SURFACE_ID_COL)
             for j in range(len(surfaceChanges) - 1):
@@ -89,8 +88,8 @@ class CLKeyLog:
         return np.concatenate(([0], indices, [log.shape[0]]))
 
     @staticmethod
-    def _sort(log: np.ndarray, column: int):
-        return log[log[:, column].argsort()]
+    def _sort(log: np.ndarray, columns: List[int]):
+        return log[np.lexsort([log[:, i] for i in columns])]
 
     def _merge(self):
         """ Merges the local batches into a single key log with unique interaction keys. """


### PR DESCRIPTION
- Use array indexing to replace propagated photons between batches. Results in a speed increase between 20% to 100% depending on scenes. 
- Minor improvement in CLKeyLog
- Minor improvement in data transfer: do not apply unstructured conversion on photon state data. 