### PR TITLE
Improve simulation progress info

### DIFF
--- a/pytissueoptics/rayscattering/opencl/utils/__init__.py
+++ b/pytissueoptics/rayscattering/opencl/utils/__init__.py
@@ -1,2 +1,3 @@
 from .CLKeyLog import CLKeyLog
 from .CLParameters import CLParameters
+from .batchTiming import BatchTiming

--- a/pytissueoptics/rayscattering/opencl/utils/batchTiming.py
+++ b/pytissueoptics/rayscattering/opencl/utils/batchTiming.py
@@ -1,0 +1,64 @@
+class BatchTiming:
+    """
+    Used to record and display the progress of a batched photon propagation.
+    """
+    def __init__(self, totalPhotons: int):
+        self._photonCount = 0
+        self._totalPhotons = totalPhotons
+        self._batchCount = 0
+
+        self._propagationTime = 0
+        self._dataTransferTime = 0
+        self._dataConversionTime = 0
+        self._totalTime = 0
+
+        self._title = "SIMULATION PROGRESS"
+        self._header = ["BATCH #", "PHOTON COUNT", "SPEED (ph/ms)", "TIME ELAPSED", "TIME LEFT"]
+
+        self._columnWidths = [len(value) + 3 for value in self._header]
+        photonCountWidth = len(str(self._totalPhotons)) + 11
+        self._columnWidths[1] = max(self._columnWidths[1], photonCountWidth)
+        self._width = sum(self._columnWidths) + 3 * (len(self._columnWidths) - 1)
+
+        self._printHeader()
+
+    def recordBatch(self, photonCount: int, propagationTime: float, dataTransferTime: float, dataConversionTime: float, totalTime: float):
+        self._photonCount += photonCount
+        self._propagationTime += propagationTime
+        self._dataTransferTime += dataTransferTime
+        self._dataConversionTime += dataConversionTime
+        self._totalTime += totalTime
+        self._batchCount += 1
+
+        self._printProgress()
+        if self._photonCount == self._totalPhotons:
+            self._printFooter()
+
+    def _printHeader(self):
+        halfBanner = "=" * ((self._width - len(self._title) - 1) // 2)
+        print(f"\n{halfBanner} {self._title} {halfBanner}")
+        formatted_header = [f"[{title}] ".center(width) for title, width in zip(self._header, self._columnWidths)]
+        print(":: ".join(formatted_header))
+
+    def _printProgress(self):
+        progress = self._photonCount / self._totalPhotons
+        speed = self._photonCount / (self._totalTime / 1e6)
+        timeElapsed = self._totalTime / 1e9
+        timeLeft = timeElapsed * (self._totalPhotons / self._photonCount) - timeElapsed
+
+        progressString = f"{self._photonCount} ({progress * 100:.1f}%)"
+        speedString = f"{speed:.2f}"
+        timeElapsedString = f"{timeElapsed:.2f} s"
+        timeLeftString = f"{timeLeft:.2f} s"
+
+        formatted_values = [f" {value} ".center(width) for value, width in
+                            zip([self._batchCount, progressString, speedString, timeElapsedString, timeLeftString], self._columnWidths)]
+        print(":: ".join(formatted_values))
+
+    def _printFooter(self):
+        print("\nComputation splits:")
+        splits = {"Propagation": self._propagationTime, "Data transfer": self._dataTransferTime,
+                  "Data conversion": self._dataConversionTime}
+        for key, value in splits.items():
+            print(f"\t{key}: {value / self._totalTime * 100:.1f}%")
+        print("".join(["=" * self._width]) + "\n")

--- a/pytissueoptics/rayscattering/opencl/utils/batchTiming.py
+++ b/pytissueoptics/rayscattering/opencl/utils/batchTiming.py
@@ -23,6 +23,12 @@ class BatchTiming:
         self._printHeader()
 
     def recordBatch(self, photonCount: int, propagationTime: float, dataTransferTime: float, dataConversionTime: float, totalTime: float):
+        """
+        Photon count is the number of photons that were propagated in the batch. The other times are in nanoseconds.
+        Propagation time is the time it took to run the propagation kernel. Data transfer time is the time it took to
+        transfer the raw 3D data from the GPU. Data conversion time is the time it took to sort and convert the 
+        interactions IDs into proper InteractionKey points. 
+        """
         self._photonCount += photonCount
         self._propagationTime += propagationTime
         self._dataTransferTime += dataTransferTime


### PR DESCRIPTION
Include average speed as photons/ms. 
Show computation splits to help spot simulation bottleneck.
The stats shown are always the average up to that point in time. So last batch results include total simulation time and average simulation speed. 

```
=============================== SIMULATION PROGRESS ===============================
[BATCH #] ::  [PHOTON COUNT]   :: [SPEED (ph/ms)] :: [TIME ELAPSED] :: [TIME LEFT] 
    1     ::   220739 (22.1%)  ::      144.19     ::      1.53 s    ::    5.40 s   
    2     ::   430281 (43.0%)  ::      165.43     ::      2.60 s    ::    3.44 s   
    3     ::   635796 (63.6%)  ::      175.60     ::      3.62 s    ::    2.07 s   
    4     ::   836646 (83.7%)  ::      179.87     ::      4.65 s    ::    0.91 s   
    5     ::   965699 (96.6%)  ::      171.74     ::      5.62 s    ::    0.20 s   
    6     ::   995379 (99.5%)  ::      154.23     ::      6.45 s    ::    0.03 s   
    7     ::  1000000 (100.0%) ::      137.56     ::      7.27 s    ::    0.00 s   

Computation splits:
        Propagation: 33.9%
        Data transfer: 25.1%
        Data conversion: 36.5%
===================================================================================
```