### PR TITLE
Add Lenses

### DIFF
--- a/pytissueoptics/examples/rayscattering/ex03.py
+++ b/pytissueoptics/examples/rayscattering/ex03.py
@@ -1,13 +1,14 @@
 import env
 from pytissueoptics import *
 
-TITLE = "Propagate in a custom scene and play with focal of different objects." \
+TITLE = "Propagate in a in a non-scattering custom scene with an optical lens." \
         "Learn to save and load your data so you don't have to simulate again."
 
 DESCRIPTION = """  
-Thin Cuboid solids are used as screens for visualization, and an Ellipsoid() as a lens. They all go into a 
+Thin Cuboid solids are used as screens for visualization, and a SymmetricLens() as a lens. They all go into a 
 RayScatteringScene which takes a list of solid. We can display our scene before propagation. Then, we repeat the
-usual steps of propagation. By changing the index 'n' of the lens material, we can see how the focal is affected.
+usual steps of propagation. You can experiment with different focal lengths and material. The symmetric thick lens will
+automatically compute the required surface curvatures to achieve the desired focal length.
 
 The logger can save data to a file. You can then use logger.load(filepath) or Logger(filepath) to load the data. 
 At that point you can comment out the line ‘source.propagate()‘ if you don't want to simulate again. You can explore 
@@ -16,31 +17,31 @@ the different views and information the object Stats provides.
 
 
 def exampleCode():
-    N = 100000 if hardwareAccelerationIsAvailable() else 2000
-    glassMaterial = ScatteringMaterial(mu_s=0.0, mu_a=0, g=0.7, n=1.34)
-    absorptiveMaterial = ScatteringMaterial(mu_s=1.0, mu_a=0.5, g=1.0)
-    blockMaterial = ScatteringMaterial(mu_s=1.0, mu_a=10, g=0.7, n=1.0)
-    
-    screen1 = Cuboid(a=4, b=4, c=0.1, position=Vector(0, 0, 3), material=absorptiveMaterial, label="Screen1")
-    screen2 = Cuboid(a=4, b=4, c=0.1, position=Vector(0, 0, 5), material=absorptiveMaterial, label="Screen2")
-    screen3 = Cuboid(a=4, b=4, c=0.1, position=Vector(0, 0, 10), material=blockMaterial, label="Screen3")
+    N = 1000000 if hardwareAccelerationIsAvailable() else 2000
+    glassMaterial = ScatteringMaterial(n=1.50)
+    vacuum = ScatteringMaterial()
+    screen1 = Cuboid(a=40, b=40, c=0.1, position=Vector(0, 0, 30), material=vacuum, label="Screen1")
+    screen2 = Cuboid(a=40, b=40, c=0.1, position=Vector(0, 0, 70), material=vacuum, label="Screen2")
+    screen3 = Cuboid(a=40, b=40, c=0.1, position=Vector(0, 0, 100.05), material=vacuum, label="Screen3")
 
-    ellipsoid = Ellipsoid(a=2, b=2, c=0.5, position=Vector(0, 0, -1), material=glassMaterial)
-    myCustomScene = ScatteringScene([screen1, screen2, screen3, ellipsoid])
-    source = DirectionalSource(position=Vector(0, 0, -3), direction=Vector(0, 0, 1), diameter=1, N=N, displaySize=0.5)
+    lens = SymmetricLens(f=100, diameter=25.4, thickness=3.6, material=glassMaterial, position=Vector(0, 0, 0))
+    myCustomScene = ScatteringScene([screen1, screen2, screen3, lens])
+    source = DirectionalSource(position=Vector(0, 0, -20), direction=Vector(0, 0, 1), diameter=20.0, N=N, displaySize=5)
 
-    myCustomScene.show(source=source)
+    myCustomScene.show(source)
 
-    logger = EnergyLogger(myCustomScene)
+    logger = EnergyLogger(myCustomScene, "ex03.log")
+    # The following line can be commented out if you only want to load the previously saved data.
+    # Or leave it in if you want to continue the simulation.
     source.propagate(myCustomScene, logger)
 
     viewer = Viewer(myCustomScene, source, logger)
     viewer.reportStats()
 
     viewer.show3D()
-    viewer.show2D(View2DProjectionZ("Screen1"), logScale=False)
-    viewer.show2D(View2DSurfaceZ("Screen2", "front", surfaceEnergyLeaving=False), logScale=False)
-    viewer.show2D(View2DProjectionZ("Screen3"))
+    viewer.show2D(View2DSurfaceZ("Screen1", "front", surfaceEnergyLeaving=False))
+    viewer.show2D(View2DSurfaceZ("Screen2", "front", surfaceEnergyLeaving=False))
+    viewer.show2D(View2DSurfaceZ("Screen3", "front", surfaceEnergyLeaving=False))
 
 
 if __name__ == "__main__":

--- a/pytissueoptics/examples/scene/example4.py
+++ b/pytissueoptics/examples/scene/example4.py
@@ -1,0 +1,23 @@
+import env
+
+TITLE = "Lenses"
+
+DESCRIPTION = """Explore different types of lens-shaped solids."""
+
+
+def exampleCode():
+    from pytissueoptics.scene import Vector, MayaviViewer, RefractiveMaterial, ThickLens, SymmetricLens, PlanoConvexLens, PlanoConcaveLens
+
+    material = RefractiveMaterial(refractiveIndex=1.44)
+    lens1 = ThickLens(30, 60, diameter=25.4, thickness=4, material=material, position=Vector(0, 0, 0))
+    lens3 = SymmetricLens(f=60, diameter=25.4, thickness=4, material=material, position=Vector(0, 0, 10))
+    lens2 = PlanoConvexLens(f=-60, diameter=25.4, thickness=4, material=material, position=Vector(0, 0, 20))
+    lens4 = PlanoConcaveLens(f=60, diameter=25.4, thickness=4, material=material, position=Vector(0, 0, 30))
+
+    viewer = MayaviViewer()
+    viewer.add(lens1, lens2, lens3, lens4, representation="surface", colormap="viridis", showNormals=False)
+    viewer.show()
+
+
+if __name__ == "__main__":
+    exampleCode()

--- a/pytissueoptics/rayscattering/materials/scatteringMaterial.py
+++ b/pytissueoptics/rayscattering/materials/scatteringMaterial.py
@@ -2,8 +2,10 @@ import math
 
 import numpy as np
 
+from pytissueoptics.scene.material import RefractiveMaterial
 
-class ScatteringMaterial:
+
+class ScatteringMaterial(RefractiveMaterial):
     def __init__(self, mu_s=0, mu_a=0, g=0, n=1.0):
         self.mu_s = mu_s
         self.mu_a = mu_a
@@ -15,7 +17,7 @@ class ScatteringMaterial:
             self._albedo = 0
 
         self.g = g
-        self.n = n
+        super().__init__(n)
 
     def getAlbedo(self):
         return self._albedo

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -280,7 +280,7 @@ void setSmoothNormal(Intersection *intersection, __global Triangle *triangles, _
     }
 
     // Do not allow the new smooth normal to have a different dot product with ray direction. 
-    // This is a rare edge case that can happen when the ray direction is approximately parallel to the surface. More comon in low resolution meshes (like icosphere of order 1)
+    // This is a rare edge case that can happen when the ray direction is approximately parallel to the surface. More common in low resolution meshes (like icosphere of order 1)
     // Not accounting for this can lead to a photon slightly going inside another solid mesh, but being considered as leaving the other solid (during FresnelIntersection calculations).
     // Which would result in the wrong next environment being set as well as the wrong step correction being applied after refraction.
     if (dot(newNormal, ray->direction) * dot(intersection->normal, ray->direction) < 0) {

--- a/pytissueoptics/rayscattering/scatteringScene.py
+++ b/pytissueoptics/rayscattering/scatteringScene.py
@@ -20,9 +20,9 @@ class ScatteringScene(Scene):
                             f"This is required for any RayScatteringScene. ")
         super().add(solid, position)
 
-    def show(self, source: Displayable = None, **kwargs):
+    def show(self, source: Displayable = None, opacity=0.8, colormap="cool", **kwargs):
         viewer = MayaviViewer()
-        self.addToViewer(viewer, **kwargs)
+        self.addToViewer(viewer, opacity=opacity, colormap=colormap, **kwargs)
         if source:
             source.addToViewer(viewer)
         viewer.show()

--- a/pytissueoptics/rayscattering/source.py
+++ b/pytissueoptics/rayscattering/source.py
@@ -200,10 +200,10 @@ class DirectionalSource(Source):
     def addToViewer(self, viewer: MayaviViewer, representation='surface', colormap='Wistia', opacity=1, **kwargs):
         baseHeight = 0.5 * self.displaySize
         baseCenter = self._position + self._direction * baseHeight/2
-        base = Cylinder(radius=self.displaySize/8, height=baseHeight, position=baseCenter)
+        base = Cylinder(radius=self.displaySize/8, length=baseHeight, position=baseCenter)
         coneHeight = self.displaySize - baseHeight
         coneCenter = self._position + self._direction * (baseHeight + coneHeight/2)
-        arrow = Cone(position=coneCenter, radius=self.displaySize/3, height=coneHeight)
+        arrow = Cone(position=coneCenter, radius=self.displaySize/3, length=coneHeight)
 
         base.orient(self._direction)
         arrow.orient(self._direction)

--- a/pytissueoptics/scene/__init__.py
+++ b/pytissueoptics/scene/__init__.py
@@ -1,9 +1,9 @@
-from .solids import Cuboid, Cube, Sphere, Ellipsoid, Cylinder, Cone
+from .solids import Cuboid, Cube, Sphere, Ellipsoid, Cylinder, Cone, Lens
 from .geometry import Vector
 from .scene import Scene
 from .loader import Loader, loadSolid
 from .viewer import MayaviViewer, MAYAVI_AVAILABLE, ViewPointStyle
 from .logger import Logger, InteractionKey
 
-__all__ = ["Cuboid", "Cube", "Sphere", "Ellipsoid", "Cylinder", "Cone", "Vector", "Scene", "Loader", "loadSolid",
-           "MayaviViewer", "MAYAVI_AVAILABLE", "ViewPointStyle", "Logger", "InteractionKey"]
+__all__ = ["Cuboid", "Cube", "Sphere", "Ellipsoid", "Cylinder", "Cone", "Lens", "Vector", "Scene", "Loader",
+           "loadSolid", "MayaviViewer", "MAYAVI_AVAILABLE", "ViewPointStyle", "Logger", "InteractionKey"]

--- a/pytissueoptics/scene/__init__.py
+++ b/pytissueoptics/scene/__init__.py
@@ -1,9 +1,11 @@
-from .solids import Cuboid, Cube, Sphere, Ellipsoid, Cylinder, Cone, Lens
+from .solids import Cuboid, Cube, Sphere, Ellipsoid, Cylinder, Cone, ThickLens, SymmetricLens, PlanoConvexLens, PlanoConcaveLens
 from .geometry import Vector
 from .scene import Scene
 from .loader import Loader, loadSolid
 from .viewer import MayaviViewer, MAYAVI_AVAILABLE, ViewPointStyle
 from .logger import Logger, InteractionKey
+from .material import RefractiveMaterial
 
-__all__ = ["Cuboid", "Cube", "Sphere", "Ellipsoid", "Cylinder", "Cone", "Lens", "Vector", "Scene", "Loader",
-           "loadSolid", "MayaviViewer", "MAYAVI_AVAILABLE", "ViewPointStyle", "Logger", "InteractionKey"]
+__all__ = ["Cuboid", "Cube", "Sphere", "Ellipsoid", "Cylinder", "Cone", "Vector", "Scene", "Loader",
+           "loadSolid", "MayaviViewer", "MAYAVI_AVAILABLE", "ViewPointStyle", "Logger", "InteractionKey",
+           "RefractiveMaterial", "ThickLens", "SymmetricLens", "PlanoConvexLens", "PlanoConcaveLens"]

--- a/pytissueoptics/scene/material.py
+++ b/pytissueoptics/scene/material.py
@@ -1,0 +1,4 @@
+
+class RefractiveMaterial:
+    def __init__(self, refractiveIndex):
+        self.n = refractiveIndex

--- a/pytissueoptics/scene/solids/__init__.py
+++ b/pytissueoptics/scene/solids/__init__.py
@@ -6,4 +6,4 @@ from .ellipsoid import Ellipsoid
 from .sphere import Sphere
 from .cylinder import Cylinder
 from .cone import Cone
-from .lens import Lens
+from .lens import ThickLens, SymmetricLens, PlanoConvexLens, PlanoConcaveLens

--- a/pytissueoptics/scene/solids/__init__.py
+++ b/pytissueoptics/scene/solids/__init__.py
@@ -6,3 +6,4 @@ from .ellipsoid import Ellipsoid
 from .sphere import Sphere
 from .cylinder import Cylinder
 from .cone import Cone
+from .lens import Lens

--- a/pytissueoptics/scene/solids/cone.py
+++ b/pytissueoptics/scene/solids/cone.py
@@ -3,13 +3,13 @@ from pytissueoptics.scene.solids import Cylinder
 
 
 class Cone(Cylinder):
-    def __init__(self, radius: float = 1, height: float = 1, u: int = 32, v: int = 3,
+    def __init__(self, radius: float = 1, length: float = 1, u: int = 32, v: int = 3, s: int = 1,
                  position: Vector = Vector(0, 0, 0), material=None, primitive: str = primitives.DEFAULT,
                  label: str = "Cone"):
-        super().__init__(radius, height, u, v, position, material, primitive, label)
+        super().__init__(radius, length, u, v, s, position, material, primitive, label)
 
     def _getShrinkFactor(self, heightAlong: float) -> float:
-        return (self._height - heightAlong) / self._height
+        return (self._length - heightAlong) / self._length
 
     def _computeQuadMesh(self):
         raise NotImplementedError("Quad mesh not implemented for Cylinder")

--- a/pytissueoptics/scene/solids/cuboid.py
+++ b/pytissueoptics/scene/solids/cuboid.py
@@ -2,7 +2,7 @@ from typing import List
 
 import numpy as np
 
-from pytissueoptics.scene.geometry import Vector, Quad, Triangle, utils, Vertex, BoundingBox, Polygon, primitives
+from pytissueoptics.scene.geometry import Vector, Quad, Triangle, Vertex, BoundingBox, Polygon, primitives
 from pytissueoptics.scene.solids import Solid
 from pytissueoptics.scene.geometry import SurfaceCollection
 from pytissueoptics.scene.solids.stack.cuboidStacker import CuboidStacker

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -7,100 +7,130 @@ from pytissueoptics.scene.solids import Solid
 
 
 class Cylinder(Solid):
-    def __init__(self, radius: float = 1, height: float = 1, u: int = 32, v: int = 3,
+    def __init__(self, radius: float = 1, length: float = 1, u: int = 32, v: int = 3, s: int = 2,
                  position: Vector = Vector(0, 0, 0), material=None,
                  primitive: str = primitives.DEFAULT, label: str = "cylinder", smooth=True):
+        """
+        Default cylinder orientation will be along the z axis. The front face towards the negative z axis and the back
+        face towards the positive z axis. Position refers to its centroid. Available surfaces are "front", "lateral" and
+        "back".
+        """
         self._radius = radius
-        self._height = height
-        if u < 3 or v < 1:
-            raise ValueError("u must be >= 3 and v must be >= 1")
+        self._length = length
+        if u < 3:
+            raise ValueError("u must be >= 3")
+        if length != 0 and v < 1:
+            raise ValueError("v must be >= 1 for non-zero length")
         self._u = u
         self._v = v
-        self._bottomCenter = Vertex(0, 0, 0)
-        self._topCenter = Vertex(0, 0, height)
+        self._s = s
+        self._frontCenter = Vertex(0, 0, 0)
+        self._backCenter = Vertex(0, 0, length)
         self._minRadius = math.cos(math.pi / self._u) * self._radius
+        self._angularStep = 2 * math.pi / self._u
+        self._lateralStep = self._length / self._v
+        self._radialStep = self._radius / self._s
+
         super().__init__(position=position, material=material, primitive=primitive,
-                         vertices=[self._bottomCenter, self._topCenter], smooth=smooth, label=label)
-        self.translateBy(Vector(0, 0, -height / 2))
-        self._position += Vector(0, 0, height / 2)
+                         vertices=[], smooth=smooth, label=label)
+        self.translateBy(Vector(0, 0, -length / 2))
+        self._position += Vector(0, 0, length / 2)
 
     @property
     def direction(self) -> Vector:
-        direction = self._topCenter - self._bottomCenter
+        direction = self._backCenter - self._frontCenter
         direction.normalize()
         return direction
 
     def _computeTriangleMesh(self):
-        verticesGroups = self._computeVertices()
-        self._computeMiddleTriangles(verticesGroups)
-        self._computeBottomTriangles(verticesGroups[0])
-        self._computeTopTriangles(verticesGroups[-1])
+        frontLayers, lateralLayers, backLayers = self._computeVerticesOfLayers()
 
-    def _computeVertices(self) -> List[List[Vertex]]:
-        verticesGroups = []
-        radianStep = 2 * math.pi / self._u
-        verticalStep = self._height / self._v
+        frontLayers.insert(0, [self._frontCenter])
+        frontLayers.append(lateralLayers[0])
+        backLayers.insert(0, lateralLayers[-1])
+        backLayers.append([self._backCenter])
+        self._vertices.extend([self._frontCenter, self._backCenter])
 
-        for j in range(0, self._v + 1):
-            currentLayer = []
-            for i in range(self._u):
-                vertex = self.getMidVertex(i, j, radianStep, verticalStep)
-                currentLayer.append(vertex)
-            verticesGroups.append(currentLayer)
-            self._vertices.extend(currentLayer)
+        self._surfaces.add("front", self._getSurfaceTriangles(frontLayers))
+        self._surfaces.add("lateral", self._getSurfaceTriangles(lateralLayers))
+        self._surfaces.add("back", self._getSurfaceTriangles(backLayers))
 
-        return verticesGroups
+    def _computeVerticesOfLayers(self) -> tuple:
+        v = self._v if self._length != 0 else 0
+        frontLayers = self._computeSectionVertices(lateralSteps=[0], radialSteps=list(range(1, self._s)))
+        lateralLayers = self._computeSectionVertices(lateralSteps=list(range(v + 1)), radialSteps=[self._s])
+        backLayers = self._computeSectionVertices(lateralSteps=[v], radialSteps=list(range(self._s-1, 0, -1)))
+        return frontLayers, lateralLayers, backLayers
 
-    def getMidVertex(self, i: int, j: int, radianStep: float, verticalStep: float) -> Vertex:
-        shrinkFactor = self._getShrinkFactor(verticalStep * j)
-        x = self._radius * shrinkFactor * math.cos(i * radianStep)
-        y = self._radius * shrinkFactor * math.sin(i * radianStep)
-        z = j * verticalStep
+    def _computeSectionVertices(self, lateralSteps: List[int], radialSteps: List[int]):
+        verticesLayers = []
+        for k in radialSteps:
+            for j in lateralSteps:
+                layer = []
+                for i in range(self._u):
+                    layer.append(self._createVertex(i, j, k))
+                verticesLayers.append(layer)
+                self._vertices.extend(layer)
+        return verticesLayers
+
+    def _createVertex(self, i: int, j: int, k: int) -> Vertex:
+        shrinkFactor = self._getShrinkFactor(self._lateralStep * j)
+        radiusFactor = k * self._radialStep / self._radius
+        if shrinkFactor != 1:
+            pass  # This is for cones only. In this case we want to keep linear sampling of radius values.
+        else:
+            # For lenses, we usually want a uniform mesh after the curve transform, but this transform tends to push
+            # vertices outwards (particularly at low radius). To prevent a low mesh resolution in the center, we need
+            # to increase the sampling around the center beforehand by forcing smaller radiusFactor values.
+            radiusFactor = radiusFactor ** 2
+        r = self._radius * radiusFactor * shrinkFactor
+        x = r * math.cos(i * self._angularStep)
+        y = r * math.sin(i * self._angularStep)
+        z = j * self._lateralStep
         return Vertex(x, y, z)
 
-    def _computeMiddleTriangles(self, verticesGroups: List[List[Vertex]]):
-        middleTriangles = []
-        for i in range(self._v):
-            currentGroup = verticesGroups[i]
-            nextGroup = verticesGroups[i + 1]
+    def _getSurfaceTriangles(self, verticesLayers: List[List[Vertex]]) -> List[Triangle]:
+        triangles = []
+        for i in range(len(verticesLayers) - 1):
+            currentGroup = verticesLayers[i]
+            nextGroup = verticesLayers[i + 1]
+
+            if len(currentGroup) == 1:
+                triangles.extend(self._getPeakTriangles(self._frontCenter, nextGroup[::-1]))
+                continue
+            if len(nextGroup) == 1:
+                triangles.extend(self._getPeakTriangles(self._backCenter, currentGroup))
+                continue
+
             for j in range(self._u):
                 nextIndex = (j + 1) % self._u
-                middleTriangles.append(Triangle(currentGroup[j], nextGroup[nextIndex], nextGroup[j]))
-                middleTriangles.append(Triangle(currentGroup[j], currentGroup[nextIndex], nextGroup[nextIndex]))
-        self._surfaces.add("middle", middleTriangles)
+                triangles.append(Triangle(currentGroup[j], nextGroup[nextIndex], nextGroup[j]))
+                triangles.append(Triangle(currentGroup[j], currentGroup[nextIndex], nextGroup[nextIndex]))
+        return triangles
 
-    def _computeBottomTriangles(self, vertices: List[Vertex]):
-        vertices.reverse()
-        bottomTriangles = []
-        for i in range(self._u):
-            nextIndex = (i + 1) % self._u
-            bottomTriangles.append(Triangle(self._bottomCenter, vertices[i], vertices[nextIndex]))
-        self._surfaces.add("bottom", bottomTriangles)
-
-    def _computeTopTriangles(self, vertices: List[Vertex]):
-        topTriangles = []
-        for i in range(self._u):
-            nextIndex = (i + 1) % self._u
-            topTriangles.append(Triangle(self._topCenter, vertices[i], vertices[nextIndex]))
-        self._surfaces.add("top", topTriangles)
+    def _getPeakTriangles(self, peakVertex: Vertex, ringVertices: List[Vertex]) -> List[Triangle]:
+        triangles = []
+        for j in range(self._u):
+            nextIndex = (j + 1) % self._u
+            triangles.append(Triangle(peakVertex, ringVertices[j], ringVertices[nextIndex]))
+        return triangles
 
     def _computeQuadMesh(self):
         raise NotImplementedError("Quad mesh not implemented for Cylinder")
 
     def contains(self, *vertices: Vector) -> bool:
         direction = self.direction
-        basePosition = self._position - direction * self._height / 2
+        basePosition = self._position - direction * self._length / 2
         for vertex in vertices:
             localPoint = vertex - basePosition
             alongCylinder = direction.dot(localPoint)
-            if alongCylinder < 0 or alongCylinder > self._height:
+            if alongCylinder < 0 or alongCylinder > self._length:
                 return False
             radiusCheck = self._minRadiusAtHeightAlong(alongCylinder)
             radialComponent = localPoint - direction * alongCylinder
             radialDistanceFromBase = radialComponent.getNorm()
             if radialDistanceFromBase > radiusCheck:
                 return False
-
         return True
 
     def _minRadiusAtHeightAlong(self, heightAlong: float) -> float:
@@ -114,4 +144,6 @@ class Cylinder(Solid):
     def smooth(self, surfaceLabel: str = None):
         if self._u < 16:
             warnings.warn("Smoothing a cylinder with less than 16 sides (u < 16) may result in intersection errors.")
-        super(Cylinder, self).smooth("middle")
+        if surfaceLabel:
+            return super(Cylinder, self).smooth(surfaceLabel)
+        self.smooth("lateral")

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -21,6 +21,7 @@ class Cylinder(Solid):
             raise ValueError("u must be >= 3")
         if length != 0 and v < 1:
             raise ValueError("v must be >= 1 for non-zero length")
+        assert radius > 0 and length >= 0
         self._u = u
         self._v = v
         self._s = s

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -142,9 +142,14 @@ class Cylinder(Solid):
     def _getShrinkFactor(heightAlong: float) -> float:
         return 1
 
-    def smooth(self, surfaceLabel: str = None):
+    def smooth(self, surfaceLabel: str = None, reset: bool = True):
         if self._u < 16:
             warnings.warn("Smoothing a cylinder with less than 16 sides (u < 16) may result in intersection errors.")
         if surfaceLabel:
-            return super(Cylinder, self).smooth(surfaceLabel)
-        self.smooth("lateral")
+            return super(Cylinder, self).smooth(surfaceLabel, reset)
+        self.smooth("lateral", reset=True)
+
+    def __hash__(self):
+        materialHash = hash(self._material) if self._material else 0
+        propertyHash = hash((self._radius, self._length, self._frontCenter, self._backCenter))
+        return hash((materialHash, propertyHash))

--- a/pytissueoptics/scene/solids/ellipsoid.py
+++ b/pytissueoptics/scene/solids/ellipsoid.py
@@ -4,7 +4,7 @@ import pickle
 
 import numpy as np
 
-from pytissueoptics.scene.geometry import Vector, Triangle, primitives, utils, Vertex
+from pytissueoptics.scene.geometry import Vector, Triangle, primitives, Vertex
 from pytissueoptics.scene.solids import Solid
 
 

--- a/pytissueoptics/scene/solids/lens.py
+++ b/pytissueoptics/scene/solids/lens.py
@@ -1,5 +1,6 @@
 import math
 from typing import List
+import itertools
 
 import numpy as np
 
@@ -11,26 +12,32 @@ class Lens(Cylinder):
     """
     The Lens is defined by a diameter, a thickness, a front radius and a back radius.
     The position refers to the vector from global origin to its centroid.
-    The generated mesh will be divided into the following subgroups: Front, Side, Back.
+    The generated mesh will be divided into the following subgroups: Front, Side and Back.
     By default, front will point towards the negative z-axis.
     """
     def __init__(self, frontRadius: float, backRadius: float, diameter: float = 2.54, thickness: float = 0,
                  position: Vector = Vector(0, 0, 0), material=None, u: int = 32, v: int = 2, s: int = 10,
                  label: str = "lens", primitive: str = primitives.DEFAULT, smooth: bool = True):
-
+        if abs(frontRadius) <= diameter / 2:
+            raise ValueError("frontRadius must be greater than the lens radius")
+        if abs(backRadius) <= diameter / 2:
+            raise ValueError("backRadius must be greater than the lens radius")
         self._diameter = diameter
         self._frontRadius = frontRadius
         self._backRadius = backRadius
-
         super().__init__(radius=diameter / 2, length=thickness, u=u, v=v, s=s, position=position,
                          material=material, label=label, primitive=primitive, smooth=smooth)
 
     def _computeVerticesOfLayers(self) -> tuple:
         frontLayers, lateralLayers, backLayers = super()._computeVerticesOfLayers()
-        frontVertices = self._vertices[:len(frontLayers) * self._u] + [self._frontCenter]
+
+        frontVertices = list(itertools.chain.from_iterable(frontLayers)) + [self._frontCenter]
         self._applyCurvature(self._frontRadius, frontVertices)
-        backVertices = self._vertices[-len(backLayers) * self._u:] + [self._backCenter]
+        backVertices = list(itertools.chain.from_iterable(backLayers)) + [self._backCenter]
         self._applyCurvature(self._backRadius, backVertices)
+
+        if self._frontCenter.z > self._backCenter.z:
+            raise ValueError("Not a valid lens: curved surfaces intersect.")
         return frontLayers, lateralLayers, backLayers
 
     def _applyCurvature(self, radius: float, vertices: List[Vertex]):

--- a/pytissueoptics/scene/solids/lens.py
+++ b/pytissueoptics/scene/solids/lens.py
@@ -6,35 +6,89 @@ import numpy as np
 
 from pytissueoptics.scene.geometry import Vector, primitives, Vertex
 from pytissueoptics.scene.solids import Cylinder
+from pytissueoptics.scene.material import RefractiveMaterial
 
 
-class Lens(Cylinder):
+class ThickLens(Cylinder):
     """
-    The Lens is defined by a diameter, a thickness, a front radius and a back radius.
+    The Lens is defined by a front radius, a back radius, a diameter and a thickness (along its center).
+    A positive frontRadius means that the front surface is convex. This is reversed for the back surface.
+    A flat surface is obtained by setting the corresponding radius to 0 or math.inf.
     The position refers to the vector from global origin to its centroid.
     The generated mesh will be divided into the following subgroups: Front, Side and Back.
     By default, front will point towards the negative z-axis.
     """
-    def __init__(self, frontRadius: float, backRadius: float, diameter: float = 2.54, thickness: float = 0,
-                 position: Vector = Vector(0, 0, 0), material=None, u: int = 32, v: int = 2, s: int = 10,
-                 label: str = "lens", primitive: str = primitives.DEFAULT, smooth: bool = True):
+    def __init__(self, frontRadius: float, backRadius: float, diameter: float, thickness: float,
+                 position: Vector = Vector(0, 0, 0), material=None, label: str = "thick lens",
+                 primitive: str = primitives.DEFAULT, smooth: bool = True, u: int = 32, v: int = 2, s: int = 10):
+        frontRadius = frontRadius if frontRadius != 0 else math.inf
+        backRadius = backRadius if backRadius != 0 else math.inf
         if abs(frontRadius) <= diameter / 2:
-            raise ValueError("frontRadius must be greater than the lens radius")
+            raise ValueError(f"Front radius must be greater than the lens radius. Front radius: {frontRadius}, "
+                             f"lens radius: {diameter / 2}")
         if abs(backRadius) <= diameter / 2:
-            raise ValueError("backRadius must be greater than the lens radius")
+            raise ValueError(f"Back radius must be greater than the lens radius. Back radius: {backRadius}, "
+                             f"lens radius: {diameter / 2}")
+
         self._diameter = diameter
         self._frontRadius = frontRadius
         self._backRadius = backRadius
-        super().__init__(radius=diameter / 2, length=thickness, u=u, v=v, s=s, position=position,
+        self._centerThickness = thickness
+
+        length = self._computeLateralLength()
+        super().__init__(radius=diameter / 2, length=length, u=u, v=v, s=s, position=position,
                          material=material, label=label, primitive=primitive, smooth=smooth)
+
+    @property
+    def _hasFrontCurvature(self) -> bool:
+        return self._frontRadius != 0 and self._frontRadius != math.inf
+
+    @property
+    def _hasBackCurvature(self) -> bool:
+        return self._backRadius != 0 and self._backRadius != math.inf
+
+    def _computeLateralLength(self) -> float:
+        """ Returns the thickness of the lens on its side. This is the length required to build the base cylinder
+        before applying the curvature. """
+        dt1, dt2 = 0, 0
+        if self._hasFrontCurvature:
+            dt1 = abs(self._frontRadius) - math.sqrt(self._frontRadius**2 - self._diameter**2/4)
+            dt1 *= np.sign(self._frontRadius)
+        if self._hasBackCurvature:
+            dt2 = abs(self._backRadius) - math.sqrt(self._backRadius**2 - self._diameter**2/4)
+            dt2 *= -np.sign(self._backRadius)
+        return max(self._centerThickness - dt1 - dt2, 0)
+
+    @property
+    def focalLength(self) -> float:
+        """ Returns the focal length of the lens in air. Requires a refractive material to be defined."""
+        if self._material is None or not issubclass(type(self._material), RefractiveMaterial):
+            raise ValueError("Cannot compute focal length without refractive material defined.")
+        # For thick lenses, the focal length is given by the lensmaker's equation:
+        # 1/f = (n - 1) * (1/R1 - 1/R2 + (n - 1) * d / (n * R1 * R2))
+        n = self._material.n
+        R1 = self._frontRadius
+        R2 = self._backRadius
+        d = self._centerThickness
+        if n == 1:
+            return math.inf
+        if self._hasFrontCurvature and self._hasBackCurvature:
+            return 1 / ((n - 1) * (1 / R1 - 1 / R2 + (n - 1) * d / (n * R1 * R2)))
+        if self._hasFrontCurvature:
+            return R1 / (n - 1)
+        if self._hasBackCurvature:
+            return R2 / (n - 1)
+        return math.inf
 
     def _computeVerticesOfLayers(self) -> tuple:
         frontLayers, lateralLayers, backLayers = super()._computeVerticesOfLayers()
 
-        frontVertices = list(itertools.chain.from_iterable(frontLayers)) + [self._frontCenter]
-        self._applyCurvature(self._frontRadius, frontVertices)
-        backVertices = list(itertools.chain.from_iterable(backLayers)) + [self._backCenter]
-        self._applyCurvature(self._backRadius, backVertices)
+        if self._hasFrontCurvature:
+            frontVertices = list(itertools.chain.from_iterable(frontLayers)) + [self._frontCenter]
+            self._applyCurvature(self._frontRadius, frontVertices)
+        if self._hasBackCurvature:
+            backVertices = list(itertools.chain.from_iterable(backLayers)) + [self._backCenter]
+            self._applyCurvature(self._backRadius, backVertices)
 
         if self._frontCenter.z > self._backCenter.z:
             raise ValueError("Not a valid lens: curved surfaces intersect.")
@@ -51,8 +105,9 @@ class Lens(Cylinder):
             direction.normalize()
             vertex.update(*(sphereOrigin + direction * abs(radius)).array)
 
-    def smooth(self, surfaceLabel: str = None):
+    def smooth(self, surfaceLabel: str = None, reset: bool = True):
         if surfaceLabel:
-            return super(Cylinder, self).smooth(surfaceLabel)
+            return super(Cylinder, self).smooth(surfaceLabel, reset)
         for surfaceLabel in self._surfaces.surfaceLabels:
-            self.smooth(surfaceLabel)
+            self.smooth(surfaceLabel, reset=False)
+

--- a/pytissueoptics/scene/solids/lens.py
+++ b/pytissueoptics/scene/solids/lens.py
@@ -111,3 +111,39 @@ class ThickLens(Cylinder):
         for surfaceLabel in self._surfaces.surfaceLabels:
             self.smooth(surfaceLabel, reset=False)
 
+
+class SymmetricLens(ThickLens):
+    """ A symmetrical thick lens of focal length `f` in air. """
+    def __init__(self, f: float, diameter: float, thickness: float, material: RefractiveMaterial,
+                 position: Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
+                 smooth: bool = True, u: int = 32, v: int = 2, s: int = 10):
+        # For thick lenses, the focal length is given by the lensmaker's equation:
+        # 1/f = (n - 1) * (1/R1 - 1/R2 + (n - 1) * d / (n * R1 * R2))
+        # with R2 = -R1, we get the following quadratic equation to solve:
+        # 1/f = (n - 1) * (2/R - (n - 1) * d / (n * R^2))
+        n = material.n
+        p = math.sqrt(f * n * (f * n - thickness)) * (n - 1) / n
+        R = f * (n - 1) + p * np.sign(f)
+        super().__init__(R, -R, diameter, thickness, position, material, label, primitive, smooth, u, v, s)
+
+
+class PlanoConvexLens(ThickLens):
+    def __init__(self, f: float, diameter: float, thickness: float, material: RefractiveMaterial,
+                 position: Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
+                 smooth: bool = True, u: int = 32, v: int = 2, s: int = 10):
+        R1 = f * (material.n - 1)
+        R2 = math.inf
+        if f < 0:
+            R1, R2 = R2, R1
+        super().__init__(R1, R2, diameter, thickness, position, material, label, primitive, smooth, u, v, s)
+
+
+class PlanoConcaveLens(ThickLens):
+    def __init__(self, f: float, diameter: float, thickness: float, material: RefractiveMaterial,
+                 position: Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
+                 smooth: bool = True, u: int = 32, v: int = 2, s: int = 10):
+        R1 = math.inf
+        R2 = f * (material.n - 1)
+        if f < 0:
+            R1, R2 = R2, R1
+        super().__init__(R1, R2, diameter, thickness, position, material, label, primitive, smooth, u, v, s)

--- a/pytissueoptics/scene/solids/lens.py
+++ b/pytissueoptics/scene/solids/lens.py
@@ -1,0 +1,51 @@
+import math
+from typing import List
+
+import numpy as np
+
+from pytissueoptics.scene.geometry import Vector, primitives, Vertex
+from pytissueoptics.scene.solids import Cylinder
+
+
+class Lens(Cylinder):
+    """
+    The Lens is defined by a diameter, a thickness, a front radius and a back radius.
+    The position refers to the vector from global origin to its centroid.
+    The generated mesh will be divided into the following subgroups: Front, Side, Back.
+    By default, front will point towards the negative z-axis.
+    """
+    def __init__(self, frontRadius: float, backRadius: float, diameter: float = 2.54, thickness: float = 0,
+                 position: Vector = Vector(0, 0, 0), material=None, u: int = 32, v: int = 2, s: int = 10,
+                 label: str = "lens", primitive: str = primitives.DEFAULT, smooth: bool = True):
+
+        self._diameter = diameter
+        self._frontRadius = frontRadius
+        self._backRadius = backRadius
+
+        super().__init__(radius=diameter / 2, length=thickness, u=u, v=v, s=s, position=position,
+                         material=material, label=label, primitive=primitive, smooth=smooth)
+
+    def _computeVerticesOfLayers(self) -> tuple:
+        frontLayers, lateralLayers, backLayers = super()._computeVerticesOfLayers()
+        frontVertices = self._vertices[:len(frontLayers) * self._u] + [self._frontCenter]
+        self._applyCurvature(self._frontRadius, frontVertices)
+        backVertices = self._vertices[-len(backLayers) * self._u:] + [self._backCenter]
+        self._applyCurvature(self._backRadius, backVertices)
+        return frontLayers, lateralLayers, backLayers
+
+    def _applyCurvature(self, radius: float, vertices: List[Vertex]):
+        # At this point, all vertices are on the same z plane.
+        surfaceZ = vertices[0].z
+        # The sphere origin is simply found by setting the z coordinate so that the distance to
+        # the surface perimeter equals the desired radius.
+        sphereOrigin = Vector(0, 0, surfaceZ + math.sqrt(radius**2 - self._radius**2) * np.sign(radius))
+        for vertex in vertices:
+            direction = vertex - sphereOrigin
+            direction.normalize()
+            vertex.update(*(sphereOrigin + direction * abs(radius)).array)
+
+    def smooth(self, surfaceLabel: str = None):
+        if surfaceLabel:
+            return super(Cylinder, self).smooth(surfaceLabel)
+        for surfaceLabel in self._surfaces.surfaceLabels:
+            self.smooth(surfaceLabel)

--- a/pytissueoptics/scene/solids/lens.py
+++ b/pytissueoptics/scene/solids/lens.py
@@ -70,6 +70,14 @@ class ThickLens(Cylinder):
         return self._length
 
     @property
+    def frontRadius(self) -> float:
+        return self._frontRadius
+
+    @property
+    def backRadius(self) -> float:
+        return self._backRadius
+
+    @property
     def focalLength(self) -> float:
         """ Returns the focal length of the lens in air. Requires a refractive material to be defined."""
         if self._material is None or not issubclass(type(self._material), RefractiveMaterial):
@@ -125,7 +133,7 @@ class ThickLens(Cylinder):
 class SymmetricLens(ThickLens):
     """ A symmetrical thick lens of focal length `f` in air. """
     def __init__(self, f: float, diameter: float, thickness: float, material: RefractiveMaterial,
-                 position: Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
+                 position: Vector = Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
                  smooth: bool = True, u: int = 24, v: int = 2, s: int = 24):
         # For thick lenses, the focal length is given by the lensmaker's equation:
         # 1/f = (n - 1) * (1/R1 - 1/R2 + (n - 1) * d / (n * R1 * R2))
@@ -139,7 +147,7 @@ class SymmetricLens(ThickLens):
 
 class PlanoConvexLens(ThickLens):
     def __init__(self, f: float, diameter: float, thickness: float, material: RefractiveMaterial,
-                 position: Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
+                 position: Vector = Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
                  smooth: bool = True, u: int = 24, v: int = 2, s: int = 24):
         R1 = f * (material.n - 1)
         R2 = math.inf
@@ -150,7 +158,7 @@ class PlanoConvexLens(ThickLens):
 
 class PlanoConcaveLens(ThickLens):
     def __init__(self, f: float, diameter: float, thickness: float, material: RefractiveMaterial,
-                 position: Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
+                 position: Vector = Vector(0, 0, 0), label: str = "lens", primitive: str = primitives.DEFAULT,
                  smooth: bool = True, u: int = 24, v: int = 2, s: int = 24):
         R1 = math.inf
         R2 = f * (material.n - 1)

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -271,7 +271,7 @@ class Solid:
     def completeSurfaceLabel(self, surfaceLabel: str) -> str:
         return self._surfaces.processLabel(surfaceLabel)
 
-    def smooth(self, surfaceLabel: str = None):
+    def smooth(self, surfaceLabel: str = None, reset: bool = True):
         """ Prepare smoothing by calculating vertex normals. This is not done
         by default. The vertex normals are used during ray-polygon intersection
         to return an interpolated (smooth) normal. A vertex normal is defined
@@ -282,8 +282,9 @@ class Solid:
         another solid implementation and calling super().smooth(surfaceLabel).
         """
         self._smoothing = True
-        for vertex in self.vertices:
-            vertex.normal = None
+        if reset:
+            for vertex in self.vertices:
+                vertex.normal = None
 
         polygons = self.getPolygons(surfaceLabel)
 

--- a/pytissueoptics/scene/solids/sphere.py
+++ b/pytissueoptics/scene/solids/sphere.py
@@ -1,4 +1,4 @@
-from pytissueoptics.scene.geometry import Vector, Vertex, primitives
+from pytissueoptics.scene.geometry import Vector, primitives
 from pytissueoptics.scene.solids import Ellipsoid
 
 

--- a/pytissueoptics/scene/tests/solids/testCone.py
+++ b/pytissueoptics/scene/tests/solids/testCone.py
@@ -10,7 +10,7 @@ class TestCone(unittest.TestCase):
         h = 3
         midRadius = r * 0.5
         f = 0.9
-        cylinder = Cone(radius=r, height=h, u=32, v=2, position=Vector(0, 0, 0))
+        cylinder = Cone(radius=r, length=h, u=32, v=2, position=Vector(0, 0, 0))
         
         vertices = [Vertex(f*midRadius, 0, 0), Vertex(0, f*midRadius, 0), Vertex(-f*midRadius, 0, 0), Vertex(0, -f*midRadius, 0), 
                     Vertex(0, 0, f*h*0.5), Vertex(0, 0, -f*h*0.5)]
@@ -22,7 +22,7 @@ class TestCone(unittest.TestCase):
         h = 3
         midRadius = r * 0.5
         f = 1.1
-        cylinder = Cone(radius=r, height=h, u=32, v=2, position=Vector(0, 0, 0))
+        cylinder = Cone(radius=r, length=h, u=32, v=2, position=Vector(0, 0, 0))
         
         vertices = [Vertex(f*midRadius, 0, 0), Vertex(0, f*midRadius, 0), Vertex(-f*midRadius, 0, 0), Vertex(0, -f*midRadius, 0), 
                     Vertex(0, 0, f*h*0.5), Vertex(0, 0, -f*h*0.5)]

--- a/pytissueoptics/scene/tests/solids/testCylinder.py
+++ b/pytissueoptics/scene/tests/solids/testCylinder.py
@@ -29,7 +29,7 @@ class TestCylinder(unittest.TestCase):
             Cylinder(v=0)
 
     def testGivenALowOrderCylinder_shouldApproachCorrectCylinderAreaTo5Percent(self):
-        cylinder = Cylinder(radius=1, height=2, u=12)
+        cylinder = Cylinder(radius=1, length=2, u=12)
         perfectCylinderArea = (2 * math.pi) + (2 * math.pi * 2)
         tolerance = 0.05
         cylinderArea = self._getTotalTrianglesArea(cylinder.getPolygons())
@@ -37,7 +37,7 @@ class TestCylinder(unittest.TestCase):
         self.assertAlmostEqual(perfectCylinderArea, cylinderArea, delta=tolerance * perfectCylinderArea)
 
     def testGivenAHighOrderCylinder_shouldApproachCorrectCylinderAreaTo1TenthOfAPercent(self):
-        cylinder = Cylinder(radius=1, height=2, u=100)
+        cylinder = Cylinder(radius=1, length=2, u=100)
         perfectCylinderArea = (2 * math.pi) + (2 * math.pi * 2)
         tolerance = 0.001
         cylinderArea = self._getTotalTrianglesArea(cylinder.getPolygons())
@@ -54,14 +54,14 @@ class TestCylinder(unittest.TestCase):
         return totalArea
 
     def testWhenContainsWithVerticesThatAreAllInsideTheCylinder_shouldReturnTrue(self):
-        cylinder = Cylinder(radius=1, height=3, u=32, v=2, position=Vector(2, 2, 0))
+        cylinder = Cylinder(radius=1, length=3, u=32, v=2, position=Vector(2, 2, 0))
         cylinder.rotate(0, 45, 0)
         vertices = [Vertex(2+1, 2, 1), Vertex(2, 2, 0.5)]
 
         self.assertTrue(cylinder.contains(*vertices))
 
     def testWhenContainsWithVerticesThatAreNotAllInsideTheCylinder_shouldReturnFalse(self):
-        cylinder = Cylinder(radius=1, height=3, u=32, v=2, position=Vector(2, 2, 0))
+        cylinder = Cylinder(radius=1, length=3, u=32, v=2, position=Vector(2, 2, 0))
         cylinder.rotate(0, 30, 0)
         vertices = [Vertex(3.51, 2, 2.6), Vertex(2, 2, 0.5)]
                 
@@ -72,7 +72,7 @@ class TestCylinder(unittest.TestCase):
         h = 3
         minRadiusWith6Divisions = 0.866
         f = minRadiusWith6Divisions * 1.01
-        cylinder = Cylinder(radius=r, height=h, u=6, position=Vector(0, 0, 0))
+        cylinder = Cylinder(radius=r, length=h, u=6, position=Vector(0, 0, 0))
         
         vertices = [Vertex(f * r, 0, 0), Vertex(0, f * r, 0), Vertex(0, 0, h * 0.51),
                     Vertex(-f * r, 0, 0), Vertex(0, -f * r, 0), Vertex(0, 0, -h * 0.51)]
@@ -85,7 +85,7 @@ class TestCylinder(unittest.TestCase):
         h = 3
         minRadiusWith6Divisions = 0.866
         f = minRadiusWith6Divisions * 0.99
-        cylinder = Cylinder(radius=r, height=h, u=6, position=Vector(0, 0, 0))
+        cylinder = Cylinder(radius=r, length=h, u=6, position=Vector(0, 0, 0))
         
         vertices = [Vertex(f * r, 0, 0), Vertex(0, f * r, 0), Vertex(0, 0, h * 0.49),
                     Vertex(-f * r, 0, 0), Vertex(0, -f * r, 0), Vertex(0, 0, -h * 0.49)]

--- a/pytissueoptics/scene/tests/solids/testThickLens.py
+++ b/pytissueoptics/scene/tests/solids/testThickLens.py
@@ -1,0 +1,167 @@
+import unittest
+import math
+
+from pytissueoptics.scene.solids import ThickLens, SymmetricLens, PlanoConvexLens, PlanoConcaveLens
+from pytissueoptics.scene.geometry import Vector
+from pytissueoptics.scene.material import RefractiveMaterial
+
+
+class TestThickLens(unittest.TestCase):
+    def testGivenAFlatLens_shouldHaveInfiniteFocalLength(self):
+        lens = ThickLens(frontRadius=0, backRadius=0, diameter=1, thickness=1,
+                         material=RefractiveMaterial(1.5))
+        self.assertEqual(math.inf, lens.focalLength)
+
+    def testGivenAFlatLens_shouldHaveCenterThicknessEqualToEdgeThickness(self):
+        t = 0.8
+        lens = ThickLens(frontRadius=0, backRadius=0, diameter=1, thickness=t)
+        self.assertEqual(t, lens.centerThickness)
+        self.assertEqual(t, lens.edgeThickness)
+
+    def testGivenALensWithoutRefractiveMaterial_shouldHaveNoFocalLength(self):
+        lens = ThickLens(frontRadius=0, backRadius=0, diameter=1, thickness=1)
+        with self.assertRaises(ValueError):
+            _ = lens.focalLength
+
+    def testGivenBiConvexLens_shouldHaveCorrectFocalLength(self):
+        R1, R2, t, n = 10, -8, 0.8, 1.5
+        lens = ThickLens(frontRadius=R1, backRadius=R2, diameter=2, thickness=t, material=RefractiveMaterial(n))
+
+        f = 1 / ((n - 1) * (1 / R1 - 1 / R2 + (n - 1) * t / (n * R1 * R2)))
+        self.assertAlmostEqual(f, lens.focalLength)
+
+    def testGivenBiConcaveLens_shouldHaveCorrectFocalLength(self):
+        R1, R2, t, n = -10, 8, 0.8, 1.5
+        lens = ThickLens(frontRadius=R1, backRadius=R2, diameter=2, thickness=t, material=RefractiveMaterial(n))
+
+        f = 1 / ((n - 1) * (1 / R1 - 1 / R2 + (n - 1) * t / (n * R1 * R2)))
+        self.assertAlmostEqual(f, lens.focalLength)
+
+    def testGivenPlanoConvexLens_shouldHaveCorrectFocalLength(self):
+        R1, R2, t, n = 0, -8, 0.8, 1.5
+        lens = ThickLens(frontRadius=R1, backRadius=R2, diameter=2, thickness=t, material=RefractiveMaterial(n))
+
+        f = R2 / (n - 1)
+        self.assertAlmostEqual(f, lens.focalLength)
+
+    def testGivenPlanoConcaveLens_shouldHaveCorrectFocalLength(self):
+        R1, R2, t, n = 0, 8, 0.8, 1.5
+        lens = ThickLens(frontRadius=R1, backRadius=R2, diameter=2, thickness=t, material=RefractiveMaterial(n))
+
+        f = R2 / (n - 1)
+        self.assertAlmostEqual(f, lens.focalLength)
+
+    def testGivenALensNotThickEnoughForItsCurvature_shouldRaiseError(self):
+        with self.assertRaises(ValueError):
+            ThickLens(frontRadius=3, backRadius=-3, diameter=2, thickness=0.1)
+
+    def testShouldHaveCenterThicknessEqualToDesiredThickness(self):
+        t = 0.8
+        lens = ThickLens(frontRadius=3, backRadius=-3, diameter=1, thickness=t)
+        self.assertAlmostEqual(t, lens.centerThickness)
+
+    def testShouldHaveDifferentEdgeThickness(self):
+        t = 0.8
+        lens = ThickLens(frontRadius=3, backRadius=-3, diameter=1, thickness=t)
+        self.assertNotAlmostEqual(t, lens.edgeThickness)
+
+    def testGivenALensWithSurfaceRadiusEqualToLensRadius_shouldRaiseError(self):
+        R = 3
+        with self.assertRaises(ValueError):
+            ThickLens(frontRadius=R, backRadius=-R, diameter=R*2, thickness=R*2)
+
+    def testShouldOnlySmoothFrontAndBackSurfaces(self):
+        lens = ThickLens(frontRadius=3, backRadius=-3, diameter=1, thickness=1)
+        self.assertTrue(lens.getPolygons("front")[0].toSmooth)
+        self.assertTrue(lens.getPolygons("back")[0].toSmooth)
+        self.assertFalse(lens.getPolygons("lateral")[0].toSmooth)
+
+    def testShouldHaveFrontSurfaceVerticesLyingOnASphereOfFrontRadiusWithNormalsPointingOutward(self):
+        R1 = 3.0
+        t = 1
+        lens = ThickLens(frontRadius=R1, backRadius=-R1, diameter=R1, thickness=t)
+        frontSphereOrigin = lens.position - Vector(0, 0, t / 2 - R1)
+        frontPolygons = lens.getPolygons("front")
+        frontDirection = lens.direction * -1
+        for polygon in frontPolygons:
+            self.assertTrue(polygon.normal.dot(frontDirection) > 0)
+            for vertex in polygon.vertices:
+                difference = vertex - frontSphereOrigin
+                self.assertAlmostEqual(R1, difference.getNorm())
+
+    def testShouldHaveBackSurfaceVerticesLyingOnASphereOfBackRadiusWithNormalsPointingOutward(self):
+        R1 = 3.0
+        t = 1
+        lens = ThickLens(frontRadius=R1, backRadius=-R1, diameter=R1, thickness=t)
+        backSphereOrigin = lens.position + Vector(0, 0, t / 2 - R1)
+        backPolygons = lens.getPolygons("back")
+        backDirection = lens.direction
+        for polygon in backPolygons:
+            self.assertTrue(polygon.normal.dot(backDirection) > 0)
+            for vertex in polygon.vertices:
+                difference = vertex - backSphereOrigin
+                self.assertAlmostEqual(R1, difference.getNorm())
+
+    def testShouldHaveLateralSurfaceVerticesLyingOnACylinderOfRadiusEqualToLensRadiusWithNormalsPointingOutward(self):
+        r = 1
+        t = 1
+        lens = ThickLens(frontRadius=3, backRadius=-3, diameter=r*2, thickness=t)
+        lateralPolygons = lens.getPolygons("lateral")
+        for polygon in lateralPolygons:
+            self.assertTrue(polygon.normal.dot(lens.direction) == 0)
+            for vertex in polygon.vertices:
+                self.assertAlmostEqual(r, vertex.x**2 + vertex.y**2)
+
+
+class TestSymmetricLens(unittest.TestCase):
+    def testGivenPositiveFocalLength_shouldCreateSymmetricThickLensWithDesiredFocalLength(self):
+        f, t, n = 10.0, 0.8, 1.5
+        lens = SymmetricLens(f=f, diameter=3, thickness=t, material=RefractiveMaterial(n))
+        self.assertAlmostEqual(f, lens.focalLength)
+        self.assertTrue(lens.frontRadius > 0)
+        self.assertAlmostEqual(lens.frontRadius, -lens.backRadius)
+        self.assertAlmostEqual(t, lens.centerThickness)
+
+    def testGivenNegativeFocalLength_shouldCreateSymmetricThickLensWithDesiredFocalLength(self):
+        f, t, n = -10.0, 0.8, 1.5
+        lens = SymmetricLens(f=f, diameter=3, thickness=t, material=RefractiveMaterial(n))
+        self.assertAlmostEqual(f, lens.focalLength)
+        self.assertTrue(lens.frontRadius < 0)
+        self.assertAlmostEqual(lens.frontRadius, -lens.backRadius)
+        self.assertAlmostEqual(t, lens.centerThickness)
+
+
+class TestPlanoConvexLens(unittest.TestCase):
+    def testGivenPositiveFocalLength_shouldCreatePlanoConvexLensWithDesiredFocalLength(self):
+        f, t, n = 10.0, 0.8, 1.5
+        lens = PlanoConvexLens(f=f, diameter=3, thickness=t, material=RefractiveMaterial(n))
+        self.assertAlmostEqual(f, lens.focalLength)
+        self.assertTrue(lens.frontRadius > 0)
+        self.assertEqual(math.inf, lens.backRadius)
+        self.assertAlmostEqual(t, lens.centerThickness)
+
+    def testGivenNegativeFocalLength_shouldCreatePlanoConvexLensWithDesiredFocalLength(self):
+        f, t, n = -10.0, 0.8, 1.5
+        lens = PlanoConvexLens(f=f, diameter=3, thickness=t, material=RefractiveMaterial(n))
+        self.assertAlmostEqual(f, lens.focalLength)
+        self.assertTrue(lens.backRadius < 0)
+        self.assertEqual(math.inf, lens.frontRadius)
+        self.assertAlmostEqual(t, lens.centerThickness)
+
+
+class TestPlanoConcaveLens(unittest.TestCase):
+    def testGivenPositiveFocalLength_shouldCreatePlanoConcaveLensWithDesiredFocalLength(self):
+        f, t, n = 10.0, 0.8, 1.5
+        lens = PlanoConcaveLens(f=f, diameter=3, thickness=t, material=RefractiveMaterial(n))
+        self.assertAlmostEqual(f, lens.focalLength)
+        self.assertTrue(lens.backRadius > 0)
+        self.assertEqual(math.inf, lens.frontRadius)
+        self.assertAlmostEqual(t, lens.centerThickness)
+
+    def testGivenNegativeFocalLength_shouldCreatePlanoConcaveLensWithDesiredFocalLength(self):
+        f, t, n = -10.0, 0.8, 1.5
+        lens = PlanoConcaveLens(f=f, diameter=3, thickness=t, material=RefractiveMaterial(n))
+        self.assertAlmostEqual(f, lens.focalLength)
+        self.assertTrue(lens.frontRadius < 0)
+        self.assertEqual(math.inf, lens.backRadius)
+        self.assertAlmostEqual(t, lens.centerThickness)


### PR DESCRIPTION
Added base lens-shaped solid called `ThickLens(R1, R2, diameter, thickness)` and a few user-friendly subclasses: `SymmetricLens(f, ...)`, `PlanoConvexLens(f, ...)`, `PlanoConcaveLens(f, ...)`. 

The polygon mesh are smoothed on both front and back faces and they also have a finer mesh resolution around the lens center for more accuracy. 

Updated `ex03.py` to use a lens instead of an ellipsoid.
![image](https://github.com/DCC-Lab/PyTissueOptics/assets/29587649/8fcca77b-db3e-44b3-abdb-e009a948c8ba)
![image](https://github.com/DCC-Lab/PyTissueOptics/assets/29587649/ed233526-2cec-4286-b7a6-7211e6a6c0fd)

Added example4.py in scene examples to showcase various lens shapes and usage.
![image](https://github.com/DCC-Lab/PyTissueOptics/assets/29587649/2a0a3433-b467-4d8b-80ec-a2c39f9816ff)
