### PR TITLE
Fix sphshells example

### DIFF
--- a/pytissueoptics/examples/benchmarks/sphshells.py
+++ b/pytissueoptics/examples/benchmarks/sphshells.py
@@ -10,13 +10,13 @@ low-scattering/low absorption material to simulate CSF-like tissue in the brain.
 def exampleCode():
     N = 100000 if hardwareAccelerationIsAvailable() else 100
 
-    outerShell = Sphere(25, order=2, material=ScatteringMaterial(mu_a=0.004, mu_s=0.009, g=0.89, n=1.37), label="outer")
-    innerShell = Sphere(23, order=2, material=ScatteringMaterial(mu_a=0.02, mu_s=9, g=0.89, n=1.37), label="inner")
-    core = Sphere(10, order=2, material=ScatteringMaterial(mu_a=0.05, mu_s=1e-6, g=1, n=1.37), label="core")
-
-    tissue = ScatteringScene([core, innerShell, outerShell])
+    outerShell = Sphere(2.5, order=2, material=ScatteringMaterial(mu_a=0.04, mu_s=0.09, g=0.89, n=1.37), label="outer")
+    innerShell = Sphere(2.3, order=2, material=ScatteringMaterial(mu_a=0.2, mu_s=90, g=0.89, n=1.37), label="inner")
+    core = Sphere(1.0, order=2, material=ScatteringMaterial(mu_a=0.5, mu_s=1e-6, g=1, n=1.37), label="core")
+    grid = Cuboid(6, 6, 6, material=ScatteringMaterial(mu_a=0.2, mu_s=70, g=0.89, n=1.37))
+    tissue = ScatteringScene([core, innerShell, outerShell, grid])
     logger = EnergyLogger(tissue, defaultBinSize=0.1)
-    source = PencilPointSource(position=Vector(0, 0, -30), direction=Vector(0, 0, 1), N=N, displaySize=2)
+    source = PencilPointSource(position=Vector(0, 0.01, -3), direction=Vector(0, 0, 1), N=N, displaySize=2)
 
     source.propagate(tissue, logger=logger)
 


### PR DESCRIPTION
ua, us were wrong, because MCX is in 1/mm.
Added the "grid" object which is essentially a box around the shells. Now within 1% of MCX shpshell result.
