### PR TITLE
Unittests warnings removal

### DIFF
--- a/pytissueoptics/rayscattering/display/viewer.py
+++ b/pytissueoptics/rayscattering/display/viewer.py
@@ -2,6 +2,7 @@ from enum import Flag
 from typing import List, Tuple, Union
 
 import numpy as np
+import os
 
 from pytissueoptics.rayscattering import utils
 from pytissueoptics.rayscattering.energyLogging import EnergyLogger
@@ -93,7 +94,7 @@ class Viewer:
     def show3D(self, visibility=Visibility.AUTO, viewsVisibility: Union[ViewGroup, List[int]] = ViewGroup.SCENE,
                pointCloudStyle=PointCloudStyle(), viewsSolidLabels: List[str] = None, viewsSurfaceLabels: List[str] = None,
                viewsLogScale: bool = True, viewsColormap: str = "viridis"):
-        if not MAYAVI_AVAILABLE or os.environ['PYTISSUE_NO3DDISPLAY','0'] == '1':
+        if not MAYAVI_AVAILABLE or os.environ.get('PYTISSUE_NO3DDISPLAY','0') == '1':
             utils.warn("Package 'mayavi' is not available. Please install it to use 3D visualizations.")
             return
 

--- a/pytissueoptics/rayscattering/display/views/view2D.py
+++ b/pytissueoptics/rayscattering/display/views/view2D.py
@@ -184,7 +184,7 @@ class View2D:
         return image
 
     def show(self, logScale: bool = True, colormap: str = 'viridis'):
-        cmap = copy.copy(matplotlib.cm.get_cmap(colormap))
+        cmap = copy.copy(matplotlib.colormaps.get_cmap(colormap))
         cmap.set_bad(cmap.colors[0])
 
         image = self.getImageData(logScale=logScale)

--- a/pytissueoptics/rayscattering/tests/opencl/src/testCLFresnel.py
+++ b/pytissueoptics/rayscattering/tests/opencl/src/testCLFresnel.py
@@ -146,7 +146,7 @@ class TestCLFresnel(unittest.TestCase):
         self.program.launchKernel("getReflectionCoefficientKernel", N=N,
                                   arguments=[np.float32(self.n1), np.float32(self.n2),
                                              np.float32(thetaIn), coefficientBuffer])
-        return float(self.program.getData(coefficientBuffer)[0])
+        return float(self.program.getData(coefficientBuffer)[0][0])
 
     def _getFresnelResult(self, fresnelBuffer) -> FresnelResult:
         fresnelIntersection = self.program.getData(fresnelBuffer)[0]

--- a/pytissueoptics/rayscattering/tests/opencl/src/testCLProgram.py
+++ b/pytissueoptics/rayscattering/tests/opencl/src/testCLProgram.py
@@ -67,9 +67,6 @@ class TestCLProgram(unittest.TestCase):
         program.launchKernel(kernelName='fillRandomFloatBuffer', N=nWorkUnits, arguments = [seeds2, valueBuffer2])
 
         # We need to sort because values are not necessarily in order
-        print(sorted(valueBuffer1.hostBuffer))
-        print(sorted(valueBuffer2.hostBuffer))
-
         for value1, value2 in zip(sorted(valueBuffer1.hostBuffer), sorted(valueBuffer2.hostBuffer)) :
             self.assertEqual(value1, value2)
 

--- a/pytissueoptics/rayscattering/tests/opencl/src/testGeneralOpenCL.py
+++ b/pytissueoptics/rayscattering/tests/opencl/src/testGeneralOpenCL.py
@@ -200,7 +200,7 @@ class TestOpenCL(unittest.TestCase):
         startTime = time.time()        
         b = a+a
         calcTime = (time.time()-startTime)*1000
-        print("\nOpenCL 1 scalar: {0:.1f} ms ".format(calcTime))
+        # print("\nOpenCL 1 scalar: {0:.1f} ms ".format(calcTime))
 
         a = np.array(object=[0]*(2<<14), dtype=pycl.cltypes.float)
         for i in range(a.size):
@@ -209,7 +209,7 @@ class TestOpenCL(unittest.TestCase):
         startTime = time.time()        
         b = a+a
         calcTime = (time.time()-startTime)*1000
-        print("\nnumpy: {0:.1f} ms ".format(calcTime))
+        # print("\nnumpy: {0:.1f} ms ".format(calcTime))
 
         a = clArray(cq=queue, shape=(2<<14,), dtype=pycl.cltypes.float)
         for i in range(a.size):
@@ -218,7 +218,7 @@ class TestOpenCL(unittest.TestCase):
         startTime = time.time()        
         b = a+a
         calcTime = (time.time()-startTime)*1000
-        print("\nOpenCL 2 scalar: {0:.1f} ms ".format(calcTime))
+        # print("\nOpenCL 2 scalar: {0:.1f} ms ".format(calcTime))
 
     @unittest.skip("Skipping for now")
     def test002ArraysWithAllocator(self):
@@ -267,7 +267,7 @@ class TestOpenCL(unittest.TestCase):
         calcTimeOpenCL2 = (time.time()-startTime)*1000
 
         self.assertTrue(calcTimeOpenCL2 < calcTimeNumpy,msg="\nNumpy is faster than OpenCL: CL1 {0:.1f} ms NP {1:.1f} ms CL2 {2:.1f} ms".format(calcTimeOpenCL1, calcTimeNumpy, calcTimeOpenCL2))
-        print("\nCL1 {0:.1f} ms NP {1:.1f} ms".format(calcTimeOpenCL2, calcTimeNumpy))
+        # print("\nCL1 {0:.1f} ms NP {1:.1f} ms".format(calcTimeOpenCL2, calcTimeNumpy))
 
     @unittest.skip("Skipping graphic tests")
     def test003PerformanceVsSize(self):
@@ -382,7 +382,7 @@ class TestOpenCL(unittest.TestCase):
 
         knl(queue, (N,), None, matrix.data, M, vector.data, result.data)
 
-        print("\n{0:0.1f} ms".format((time.time()-startTime)*1000))
+        # print("\n{0:0.1f} ms".format((time.time()-startTime)*1000))
 
 
 class TestOpenCLIds(unittest.TestCase):


### PR DESCRIPTION
There were three warnings during unit tests that were fixed, and useless prints were removed.
Two warnings were not possible to remove:
1. Cylinder smoothing with less than 16 sides (unable to catch stderr for some reason)
2. secure coding warning, macOS-specific (this will go away on macOS sequoia).