### PR TITLE
Fix intersection mechanic around floating-point limit.

### DIFF
--- a/pytissueoptics/rayscattering/fresnel.py
+++ b/pytissueoptics/rayscattering/fresnel.py
@@ -56,7 +56,7 @@ class FresnelIntersect:
 
     def _getIsReflected(self) -> bool:
         R = self._getReflectionCoefficient()
-        if random.random() < R:
+        if random.random() <= R:
             return True
         return False
 

--- a/pytissueoptics/rayscattering/materials/scatteringMaterial.py
+++ b/pytissueoptics/rayscattering/materials/scatteringMaterial.py
@@ -1,4 +1,5 @@
 import math
+import random
 
 import numpy as np
 
@@ -32,16 +33,16 @@ class ScatteringMaterial(RefractiveMaterial):
 
         rnd = 0
         while rnd == 0:
-            rnd = np.random.random()
+            rnd = random.random()
         return -np.log(rnd) / self.mu_t
 
     def getScatteringAngles(self):
-        phi = np.random.random() * 2 * np.pi
+        phi = random.random() * 2 * np.pi
         g = self.g
         if g == 0:
-            cost = 2 * np.random.random() - 1
+            cost = 2 * random.random() - 1
         else:
-            temp = (1 - g * g) / (1 - g + 2 * g * np.random.random())
+            temp = (1 - g * g) / (1 - g + 2 * g * random.random())
             cost = (1 + g * g - temp * temp) / (2 * g)
         return np.arccos(cost), phi
 

--- a/pytissueoptics/rayscattering/opencl/CLScene.py
+++ b/pytissueoptics/rayscattering/opencl/CLScene.py
@@ -124,7 +124,7 @@ class CLScene:
 
         lastSolid = None
         for i, triangle in enumerate(polygons):
-            # todo: do this polygon processing only if it's a stack ?
+            # todo: consider skipping this step if the solid is not a stack.
             currentSolid = triangle.insideEnvironment.solid
             if lastSolid and lastSolid != currentSolid:
                 self._compileSurface(polygonRef=polygons[i - 1],

--- a/pytissueoptics/rayscattering/opencl/buffers/materialCL.py
+++ b/pytissueoptics/rayscattering/opencl/buffers/materialCL.py
@@ -19,9 +19,6 @@ class MaterialCL(CLObject):
         super().__init__(buildOnce=True)
 
     def _getInitialHostBuffer(self) -> np.ndarray:
-        # todo: there might be a way to abstract both struct and buffer under a single def (DRY, PO)
-        #  the cl.types above are actually np types. so we could extract clTypeX and do clTypeX(mat.propertyX) ...
-        #  except the float3 thing maybe...
         buffer = np.empty(len(self._materials), dtype=self._dtype)
         for i, material in enumerate(self._materials):
             buffer[i]["mu_s"] = np.float32(material.mu_s)

--- a/pytissueoptics/rayscattering/opencl/buffers/triangleCL.py
+++ b/pytissueoptics/rayscattering/opencl/buffers/triangleCL.py
@@ -1,8 +1,7 @@
 from typing import List, NamedTuple
 
-from pytissueoptics.scene.geometry import Vector
 from pytissueoptics.rayscattering.opencl.buffers.CLObject import *
-
+from pytissueoptics.scene.geometry import Vector
 
 TriangleCLInfo = NamedTuple("TriangleInfo", [("vertexIDs", list), ("normal", Vector)])
 
@@ -10,8 +9,9 @@ TriangleCLInfo = NamedTuple("TriangleInfo", [("vertexIDs", list), ("normal", Vec
 class TriangleCL(CLObject):
     STRUCT_NAME = "Triangle"
     STRUCT_DTYPE = np.dtype(
-            [("vertexIDs", cl.cltypes.uint, 3),
-             ("normal", cl.cltypes.float3)])  # todo: if too heavy, remove and compute on the fly with vertice
+        [("vertexIDs", cl.cltypes.uint, 3),
+         ("normal", cl.cltypes.float3)]
+    )
 
     def __init__(self, trianglesInfo: List[TriangleCLInfo]):
         self._trianglesInfo = trianglesInfo

--- a/pytissueoptics/rayscattering/opencl/src/fresnel.c
+++ b/pytissueoptics/rayscattering/opencl/src/fresnel.c
@@ -40,7 +40,7 @@ float _getReflectionCoefficient(float n1, float n2, float thetaIn) {
 bool _getIsReflected(float nIn, float nOut, float thetaIn, __global uint *seeds, uint gid) {
     float R = _getReflectionCoefficient(nIn, nOut, thetaIn);
     float randomFloat = getRandomFloatValue(seeds, gid);
-    if (R > randomFloat) {
+    if (R >= randomFloat) {
         return true;
     }
     return false;

--- a/pytissueoptics/rayscattering/opencl/src/fresnel.c
+++ b/pytissueoptics/rayscattering/opencl/src/fresnel.c
@@ -107,7 +107,6 @@ FresnelIntersection computeFresnelIntersection(float3 rayDirection, Intersection
 Intersection getLocalIntersection(__global Intersection *intersections, uint gid) {
     Intersection intersection;
     intersection.exists = intersections[gid].exists;
-    intersection.isTooClose = intersections[gid].isTooClose;
     intersection.distance = intersections[gid].distance;
     intersection.position = intersections[gid].position;
     intersection.normal = intersections[gid].normal;

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -360,8 +360,10 @@ Intersection findIntersection(Ray ray, Scene *scene, uint gid, uint photonSolidI
             // Default buffer value -1 means that there is no intersection with this solid
             continue;
         }
-        bool contained = scene->solidCandidates[boxGID].distance == 0;
-        if (!contained && closestIntersection.exists) {
+
+        if (scene->solidCandidates[boxGID].distance > closestIntersection.distance) {
+            // The solid candidates are sorted by distance, so we can break early if the BBox distance
+            // is greater than the closest intersection found so far.
             break;
         }
 

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -211,7 +211,20 @@ HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3, floa
         hitPoint.position = ray.origin + ray.length * ray.direction;
         return hitPoint;
     }
-    if (t < 0 && dt_T < EPS_CATCH) {
+    if (t <= 0 && dt_T < EPS_CATCH) {
+        // Create a test ray to compute if the origin lies inside the triangle (from the normal).
+        pVector = cross(normal, edgeB);
+        det = dot(edgeA, pVector);
+        invDet = 1.0f / det;
+        u = dot(tVector, pVector) * invDet;
+        if (u < 0.0f || u > 1.0f) {
+            return hitPoint;
+        }
+
+        v = dot(normal, qVector) * invDet;
+        if (v < 0.0f || u + v > 1.0f) {
+            return hitPoint;
+        }
         hitPoint.exists = true;
         hitPoint.distance = 0;
         hitPoint.position = ray.origin;

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -164,7 +164,6 @@ typedef struct HitPoint HitPoint;
 HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3, float3 normal) {
     HitPoint hitPoint;
     hitPoint.exists = false;
-    hitPoint.isTooClose = false;
 
     float3 edgeA = v2 - v1;
     float3 edgeB = v3 - v1;
@@ -240,7 +239,6 @@ Intersection _findClosestPolygonIntersection(Ray ray, uint solidID,
                                             uint photonSolidID) {
     Intersection intersection;
     intersection.exists = false;
-    intersection.isTooClose = false;
     intersection.distance = INFINITY;
     for (uint s = solids[solidID-1].firstSurfaceID; s <= solids[solidID-1].lastSurfaceID; s++) {
         for (uint p = surfaces[s].firstPolygonID; p <= surfaces[s].lastPolygonID; p++) {
@@ -351,7 +349,6 @@ Intersection findIntersection(Ray ray, Scene *scene, uint gid, uint photonSolidI
 
     Intersection closestIntersection;
     closestIntersection.exists = false;
-    closestIntersection.isTooClose = false;
     closestIntersection.distance = INFINITY;
     if (scene->nSolids == 0) {
         return closestIntersection;

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -1,5 +1,4 @@
-__constant float EPS = 0.00001f;
-__constant float EPS_CORRECTION = 0.0005f;
+__constant float EPS_CATCH = 0.000001f;
 __constant float EPS_PARALLEL = 0.00001f;
 __constant float EPS_SIDE = 0.000001f;
 
@@ -113,11 +112,17 @@ GemsBoxIntersection _getBBoxIntersection(Ray ray, float3 minCornerVector, float3
     return intersection;
 }
 
-void _findBBoxIntersectingSolids(Ray ray, Scene *scene, uint gid){
+void _findBBoxIntersectingSolids(Ray ray, Scene *scene, uint gid, uint photonSolidID) {
 
     for (uint i = 0; i < scene->nSolids; i++) {
         uint boxGID = gid * scene->nSolids + i;
-        scene->solidCandidates[boxGID].solidID = i + 1;
+        uint solidID = i + 1;
+        scene->solidCandidates[boxGID].solidID = solidID;
+
+        if (solidID == photonSolidID) {
+            scene->solidCandidates[boxGID].distance = 0;
+            continue;
+        }
 
         GemsBoxIntersection gemsIntersection = _getBBoxIntersection(ray, scene->solids[i].bbox_min, scene->solids[i].bbox_max);
         if (gemsIntersection.rayIsInside) {
@@ -155,7 +160,7 @@ struct HitPoint {
 
 typedef struct HitPoint HitPoint;
 
-HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3) {
+HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3, float3 normal) {
     HitPoint hitPoint;
     hitPoint.exists = false;
     hitPoint.isTooClose = false;
@@ -185,35 +190,46 @@ HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3) {
 
     float t = dot(edgeB, qVector) * invDet;
 
-    if (t < 0.0f) {
+    if (t > 0 && ray.length > t){
+        hitPoint.exists = true;
+        hitPoint.position = ray.origin + t * ray.direction;
         return hitPoint;
     }
 
-    if (t > (ray.length + EPS)) {
-        // No Intersection, it's too far away
+    float dt = t - ray.length;
+    float dt_T = fabs(dot(normal, ray.direction) * dt);
+    if (t > ray.length && dt_T < EPS_CATCH) {
+        hitPoint.exists = true;
+        hitPoint.position = ray.origin + ray.length * ray.direction;
         return hitPoint;
-    } else if (t > ray.length) {
-        // Just a bit too far away. There is no intersection, but we cannot accept photon to land here.
-        // hitPoint will also be returned with exists = true in order to consider this event and possibly process it if it was the closest "hit".
-        hitPoint.isTooClose = true;
+    }
+    if (t < 0 && dt_T < EPS_CATCH) {
+        hitPoint.exists = true;
+        hitPoint.position = ray.origin;
+        return hitPoint;
     }
 
-    hitPoint.exists = true;
-    hitPoint.position = ray.origin + t * ray.direction;
     return hitPoint;
 }
 
 Intersection _findClosestPolygonIntersection(Ray ray, uint solidID,
                                             __global Solid *solids, __global Surface *surfaces,
-                                            __global Triangle *triangles, __global Vertex *vertices) {
+                                            __global Triangle *triangles, __global Vertex *vertices,
+                                            uint photonSolidID) {
     Intersection intersection;
     intersection.exists = false;
     intersection.isTooClose = false;
     intersection.distance = INFINITY;
     for (uint s = solids[solidID-1].firstSurfaceID; s <= solids[solidID-1].lastSurfaceID; s++) {
         for (uint p = surfaces[s].firstPolygonID; p <= surfaces[s].lastPolygonID; p++) {
+            bool isGoingInside = dot(ray.direction, triangles[p].normal) < 0;
+            uint nextSolidID = isGoingInside ? surfaces[s].insideSolidID : surfaces[s].outsideSolidID;
+            if (nextSolidID == photonSolidID) {
+                continue;
+            }
+
             uint vertexIDs[3] = {triangles[p].vertexIDs[0], triangles[p].vertexIDs[1], triangles[p].vertexIDs[2]};
-            HitPoint hitPoint = _getTriangleIntersection(ray, vertices[vertexIDs[0]].position, vertices[vertexIDs[1]].position, vertices[vertexIDs[2]].position);
+            HitPoint hitPoint = _getTriangleIntersection(ray, vertices[vertexIDs[0]].position, vertices[vertexIDs[1]].position, vertices[vertexIDs[2]].position, triangles[p].normal);
             if (!hitPoint.exists) {
                 continue;
             }
@@ -301,12 +317,12 @@ void _composeIntersection(Intersection *intersection, Ray *ray, Scene *scene) {
     intersection->distanceLeft = ray->length - intersection->distance;
 }
 
-Intersection findIntersection(Ray ray, Scene *scene, uint gid) {
+Intersection findIntersection(Ray ray, Scene *scene, uint gid, uint photonSolidID) {
     /*
     OpenCL implementation of the Python module SimpleIntersectionFinder
     See the Python module documentation for more details.
     */
-    _findBBoxIntersectingSolids(ray, scene, gid);
+    _findBBoxIntersectingSolids(ray, scene, gid, photonSolidID);
     _sortSolidCandidates(scene, gid);
 
     Intersection closestIntersection;
@@ -329,7 +345,7 @@ Intersection findIntersection(Ray ray, Scene *scene, uint gid) {
         }
 
         uint solidID = scene->solidCandidates[boxGID].solidID;
-        Intersection intersection = _findClosestPolygonIntersection(ray, solidID, scene->solids, scene->surfaces, scene->triangles, scene->vertices);
+        Intersection intersection = _findClosestPolygonIntersection(ray, solidID, scene->solids, scene->surfaces, scene->triangles, scene->vertices, photonSolidID);
         if (intersection.exists  && intersection.distance < closestIntersection.distance) {
             closestIntersection = intersection;
         }
@@ -345,7 +361,7 @@ __kernel void findIntersections(__global Ray *rays, uint nSolids, __global Solid
         __global Triangle *triangles, __global Vertex *vertices, __global SolidCandidate *solidCandidates, __global Intersection *intersections) {
     uint gid = get_global_id(0);
     Scene scene = {nSolids, solids, surfaces, triangles, vertices, solidCandidates};
-    intersections[gid] = findIntersection(rays[gid], &scene, gid);
+    intersections[gid] = findIntersection(rays[gid], &scene, gid, 0);
 }
 
 

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -10,6 +10,8 @@ struct Intersection {
     uint surfaceID;
     uint polygonID;
     float distanceLeft;
+    bool isSmooth;
+    float3 rawNormal;
 };
 
 typedef struct Intersection Intersection;
@@ -305,10 +307,13 @@ void setSmoothNormal(Intersection *intersection, __global Triangle *triangles, _
     // Not accounting for this can lead to a photon slightly going inside another solid mesh, but being considered as leaving the other solid (during FresnelIntersection calculations).
     // Which would result in the wrong next environment being set as well as the wrong step correction being applied after refraction.
     if (dot(newNormal, ray->direction) * dot(intersection->normal, ray->direction) < 0) {
+        intersection->isSmooth = false;
         return;
     }
-    intersection->normal = newNormal;
-    intersection->normal = normalize(intersection->normal);
+    intersection->normal = normalize(newNormal);
+
+    intersection->isSmooth = true;
+    intersection->rawNormal = triangles[intersection->polygonID].normal;
 }
 
 void _composeIntersection(Intersection *intersection, Ray *ray, Scene *scene) {
@@ -316,6 +321,7 @@ void _composeIntersection(Intersection *intersection, Ray *ray, Scene *scene) {
         return;
     }
 
+    intersection->isSmooth = false;
     if (scene->surfaces[intersection->surfaceID].toSmooth) {
         setSmoothNormal(intersection, scene->triangles, scene->vertices, ray);
     }

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -426,5 +426,11 @@ __kernel void findIntersections(__global Ray *rays, uint nSolids, __global Solid
 
 __kernel void setSmoothNormals(__global Intersection *intersections, __global Triangle *triangles, __global Vertex *vertices, __global Ray *rays) {
     uint gid = get_global_id(0);
-    setSmoothNormal(&intersections[gid], triangles, vertices, &rays[gid]);
+    Intersection intersection = intersections[gid];
+    Ray ray = rays[gid];
+
+    setSmoothNormal(&intersection, triangles, vertices, &ray);
+
+    intersections[gid] = intersection;
+    rays[gid] = ray;
 }

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -233,6 +233,11 @@ HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3, floa
     if (t < 0 && (t > -EPS_BACK_CATCH || dt_T < EPS_CATCH)) {
         // Backward catch.
         hitPoint.exists = true;
+
+        // If ray lies on the triangle, return a distance of 0 to prioritize this intersection.
+        if (dt_T < EPS) {
+            hitPoint.distance = 0;
+        }
         return hitPoint;
     }
 

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -190,7 +190,7 @@ HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3, floa
 
     float t = dot(edgeB, qVector) * invDet;
 
-    if (t > 0 && ray.length > t){
+    if (t > 0 && ray.length >= t){
         hitPoint.exists = true;
         hitPoint.position = ray.origin + t * ray.direction;
         return hitPoint;
@@ -346,7 +346,7 @@ Intersection findIntersection(Ray ray, Scene *scene, uint gid, uint photonSolidI
 
         uint solidID = scene->solidCandidates[boxGID].solidID;
         Intersection intersection = _findClosestPolygonIntersection(ray, solidID, scene->solids, scene->surfaces, scene->triangles, scene->vertices, photonSolidID);
-        if (intersection.exists  && intersection.distance < closestIntersection.distance) {
+        if (intersection.exists && intersection.distance < closestIntersection.distance) {
             closestIntersection = intersection;
         }
     }

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -255,6 +255,12 @@ Intersection _findClosestPolygonIntersection(Ray ray, uint solidID,
     float minSameSolidDistance = -INFINITY;
 
     for (uint s = solids[solidID-1].firstSurfaceID; s <= solids[solidID-1].lastSurfaceID; s++) {
+        // When an interface joins a side surface, an outside photon could try to intersect with the interface
+        //  while this is not allowed. So we skip these tests (where surface environments dont match the photon).
+        if (photonSolidID != surfaces[s].insideSolidID && photonSolidID != surfaces[s].outsideSolidID) {
+            continue;
+        }
+
         for (uint p = surfaces[s].firstPolygonID; p <= surfaces[s].lastPolygonID; p++) {
             uint vertexIDs[3] = {triangles[p].vertexIDs[0], triangles[p].vertexIDs[1], triangles[p].vertexIDs[2]};
             HitPoint hitPoint = _getTriangleIntersection(ray, vertices[vertexIDs[0]].position, vertices[vertexIDs[1]].position, vertices[vertexIDs[2]].position, triangles[p].normal);

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -189,11 +189,11 @@ HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3, floa
     }
 
     float t = dot(edgeB, qVector) * invDet;
+    hitPoint.distance = t;
+    hitPoint.position = ray.origin + t * ray.direction;
 
     if (t > 0 && ray.length >= t){
         hitPoint.exists = true;
-        hitPoint.distance = t;
-        hitPoint.position = ray.origin + t * ray.direction;
         return hitPoint;
     }
 
@@ -204,10 +204,10 @@ HitPoint _getTriangleIntersection(Ray ray, float3 v1, float3 v2, float3 v3, floa
         dt = t - ray.length;
     }
     float dt_T = fabs(dot(normal, ray.direction) * dt);
+
     if (t > ray.length && dt_T < EPS_CATCH) {
+        // Forward catch.
         hitPoint.exists = true;
-        hitPoint.distance = ray.length;
-        hitPoint.position = ray.origin + ray.length * ray.direction;
         return hitPoint;
     }
     if (t <= 0 && dt_T < EPS_CATCH) {

--- a/pytissueoptics/rayscattering/opencl/src/intersection.c
+++ b/pytissueoptics/rayscattering/opencl/src/intersection.c
@@ -420,7 +420,7 @@ __kernel void findIntersections(__global Ray *rays, uint nSolids, __global Solid
         __global Triangle *triangles, __global Vertex *vertices, __global SolidCandidate *solidCandidates, __global Intersection *intersections) {
     uint gid = get_global_id(0);
     Scene scene = {nSolids, solids, surfaces, triangles, vertices, solidCandidates};
-    intersections[gid] = findIntersection(rays[gid], &scene, gid, 0);
+    intersections[gid] = findIntersection(rays[gid], &scene, gid, -1);
 }
 
 

--- a/pytissueoptics/rayscattering/opencl/src/propagation.c
+++ b/pytissueoptics/rayscattering/opencl/src/propagation.c
@@ -13,7 +13,8 @@ void moveBy(float distance, __global Photon *photons, uint photonID){
 }
 
 void scatterBy(float phi, float theta, __global Photon *photons, uint photonID){
-    spin(&photons[photonID].direction, theta, phi);
+    rotateAroundAxisGlobal(&photons[photonID].er, &photons[photonID].direction, phi);
+    rotateAroundAxisGlobal(&photons[photonID].direction, &photons[photonID].er, theta);
 }
 
 void decreaseWeightBy(float delta_weight, __global Photon *photons, uint photonID){

--- a/pytissueoptics/rayscattering/opencl/src/propagation.c
+++ b/pytissueoptics/rayscattering/opencl/src/propagation.c
@@ -292,10 +292,12 @@ __kernel void reflectOrRefractKernel(float3 normal, int surfaceID, float distanc
 }
 
 __kernel void propagateStepKernel(float distance, __constant Material *materials, __global Surface *surfaces,
-                    __global uint *seeds, __global DataPoint *logger, uint logIndex,
+                    __global Triangle *triangles, __global Vertex *vertices, __global uint *seeds, __global DataPoint *logger, uint logIndex,
                     __global Photon *photons, uint photonID){
     Scene scene;
     scene.surfaces = surfaces;
+    scene.triangles = triangles;
+    scene.vertices = vertices;
     uint gid = photonID;
     propagateStep(distance, photons, materials, &scene, seeds, logger, &logIndex, gid, photonID);
 }

--- a/pytissueoptics/rayscattering/opencl/src/propagation.c
+++ b/pytissueoptics/rayscattering/opencl/src/propagation.c
@@ -12,8 +12,7 @@ void moveBy(float distance, __global Photon *photons, uint photonID){
 }
 
 void scatterBy(float phi, float theta, __global Photon *photons, uint photonID){
-    rotateAroundAxisGlobal(&photons[photonID].er, &photons[photonID].direction, phi);
-    rotateAroundAxisGlobal(&photons[photonID].direction, &photons[photonID].er, theta);
+    spin(&photons[photonID].direction, theta, phi);
 }
 
 void decreaseWeightBy(float delta_weight, __global Photon *photons, uint photonID){

--- a/pytissueoptics/rayscattering/opencl/src/propagation.c
+++ b/pytissueoptics/rayscattering/opencl/src/propagation.c
@@ -15,6 +15,7 @@ void moveBy(float distance, __global Photon *photons, uint photonID){
 void scatterBy(float phi, float theta, __global Photon *photons, uint photonID){
     rotateAroundAxisGlobal(&photons[photonID].er, &photons[photonID].direction, phi);
     rotateAroundAxisGlobal(&photons[photonID].direction, &photons[photonID].er, theta);
+    photons[photonID].er = getAnyOrthogonalGlobal(&photons[photonID].direction);
 }
 
 void decreaseWeightBy(float delta_weight, __global Photon *photons, uint photonID){

--- a/pytissueoptics/rayscattering/opencl/src/vectorOperators.c
+++ b/pytissueoptics/rayscattering/opencl/src/vectorOperators.c
@@ -1,4 +1,3 @@
-__constant float COS_ZERO = 0.999999f;
 
 void normalizeVectorLocal(float3 *vector){
     float length = sqrt(vector->x * vector->x + vector->y * vector->y + vector->z * vector->z);
@@ -66,29 +65,6 @@ void rotateAround(__global float3 *mainVector, float3 *axisVector, float theta){
     mainVector->x = x;
     mainVector->y = y;
     mainVector->z = z;
-}
-
-void spin(__global float3 *mainVector, float theta, float phi){
-    float cosp = cos(phi);
-    float sinp = phi < M_PI ? sqrt(1 - cosp*cosp) : -sqrt(1 - cosp*cosp);
-    float cost = cos(theta);
-    float sint = sqrt(1 - cost*cost);
-    float ux, uy, uz;
-    if (fabs(mainVector->z) > COS_ZERO){
-        ux = sint*cosp;
-        uy = sint*sinp;
-        uz = cost * (mainVector->z >= 0 ? 1 : -1);
-    }
-    else{
-        float temp = sqrt(1 - mainVector->z*mainVector->z);
-        ux = sint*(mainVector->x*mainVector->z*cosp - mainVector->y*sinp) / temp + mainVector->x*cost;
-        uy = sint*(mainVector->y*mainVector->z*cosp + mainVector->x*sinp) / temp + mainVector->y*cost;
-        uz = -sint*cosp*temp + mainVector->z*cost;
-    }
-    mainVector->x = ux;
-    mainVector->y = uy;
-    mainVector->z = uz;
-    normalizeVectorGlobal(mainVector);
 }
 
 float3 getAnyOrthogonalGlobal(__global float3 *vector){

--- a/pytissueoptics/rayscattering/opencl/src/vectorOperators.c
+++ b/pytissueoptics/rayscattering/opencl/src/vectorOperators.c
@@ -1,3 +1,4 @@
+__constant float COS_ZERO = 0.999999f;
 
 void normalizeVectorLocal(float3 *vector){
     float length = sqrt(vector->x * vector->x + vector->y * vector->y + vector->z * vector->z);
@@ -65,6 +66,28 @@ void rotateAround(__global float3 *mainVector, float3 *axisVector, float theta){
     mainVector->x = x;
     mainVector->y = y;
     mainVector->z = z;
+}
+
+void spin(__global float3 *mainVector, float theta, float phi){
+    float cosp = cos(phi);
+    float sinp = phi < M_PI ? sqrt(1 - cosp*cosp) : -sqrt(1 - cosp*cosp);
+    float cost = cos(theta);
+    float sint = sqrt(1 - cost*cost);
+    float ux, uy, uz;
+    if (fabs(mainVector->z) > COS_ZERO){
+        ux = sint*cosp;
+        uy = sint*sinp;
+        uz = cost * (mainVector->z >= 0 ? 1 : -1);
+    }
+    else{
+        float temp = sqrt(1 - mainVector->z*mainVector->z);
+        ux = sint*(mainVector->x*mainVector->z*cosp - mainVector->y*sinp) / temp + mainVector->x*cost;
+        uy = sint*(mainVector->y*mainVector->z*cosp + mainVector->x*sinp) / temp + mainVector->y*cost;
+        uz = -sint*cosp*temp + mainVector->z*cost;
+    }
+    mainVector->x = ux;
+    mainVector->y = uy;
+    mainVector->z = uz;
 }
 
 float3 getAnyOrthogonalGlobal(__global float3 *vector){

--- a/pytissueoptics/rayscattering/opencl/src/vectorOperators.c
+++ b/pytissueoptics/rayscattering/opencl/src/vectorOperators.c
@@ -88,6 +88,7 @@ void spin(__global float3 *mainVector, float theta, float phi){
     mainVector->x = ux;
     mainVector->y = uy;
     mainVector->z = uz;
+    normalizeVectorGlobal(mainVector);
 }
 
 float3 getAnyOrthogonalGlobal(__global float3 *vector){

--- a/pytissueoptics/rayscattering/photon.py
+++ b/pytissueoptics/rayscattering/photon.py
@@ -168,8 +168,7 @@ class Photon:
         self.interact()
 
     def scatterBy(self, theta, phi):
-        self._er.rotateAround(self._direction, phi)
-        self._direction.rotateAround(self._er, theta)
+        self._direction.spin(theta, phi)
 
     def interact(self):
         delta = self._weight * self.material.getAlbedo()

--- a/pytissueoptics/rayscattering/photon.py
+++ b/pytissueoptics/rayscattering/photon.py
@@ -74,13 +74,16 @@ class Photon:
             self.roulette()
 
     def step(self, distance=0) -> float:
-        if distance == 0:
-            distance = self.material.getScatteringDistance()
+        if distance <= 0:
+            distance += self.material.getScatteringDistance()
+            if distance < 0:
+                # Not really possible until mu_t is very high (> 1000) and intense smoothing is applied (order-1 spheres).
+                distance = 0
 
         intersection = self._getIntersection(distance)
 
         if intersection:
-            self.moveBy(intersection.distance)
+            self.moveTo(intersection.position)
             distanceLeft = self.reflectOrRefract(intersection)
         else:
             if math.isinf(distance):
@@ -142,6 +145,9 @@ class Photon:
 
     def moveBy(self, distance):
         self._position += self._direction * distance
+
+    def moveTo(self, position: Vector):
+        self._position = position
 
     def reflect(self, fresnelIntersection: FresnelIntersection):
         self._direction.rotateAround(fresnelIntersection.incidencePlane,

--- a/pytissueoptics/rayscattering/photon.py
+++ b/pytissueoptics/rayscattering/photon.py
@@ -158,7 +158,8 @@ class Photon:
         self.interact()
 
     def scatterBy(self, theta, phi):
-        self._direction.spin(theta, phi)
+        self._er.rotateAround(self._direction, phi)
+        self._direction.rotateAround(self._er, theta)
 
     def interact(self):
         delta = self._weight * self.material.getAlbedo()

--- a/pytissueoptics/rayscattering/photon.py
+++ b/pytissueoptics/rayscattering/photon.py
@@ -82,6 +82,20 @@ class Photon:
         if intersection:
             self.moveTo(intersection.position)
             distanceLeft = self.reflectOrRefract(intersection)
+
+            # Check if intersection lies too close to a vertex.
+            for vertex in intersection.polygon.vertices:
+                if (intersection.position - vertex).getNorm() > 3e-7:
+                    continue
+                # If too close to a vertex, move photon away slightly.
+                stepSign = 1
+                solidLabelTowardsNormal = intersection.outsideEnvironment.solidLabel
+                if solidLabelTowardsNormal != self.solidLabel:
+                    stepSign = -1
+                stepCorrection = vertex.normal * stepSign * 1e-7
+                self._position += stepCorrection
+                break
+
         else:
             if math.isinf(distance):
                 self._weight = 0

--- a/pytissueoptics/rayscattering/photon.py
+++ b/pytissueoptics/rayscattering/photon.py
@@ -24,7 +24,6 @@ class Photon:
         self._environment: Environment = None
 
         self._er = self._direction.getAnyOrthogonal()
-        self._er.normalize()
         self._hasContext = False
         self._fresnelIntersect: FresnelIntersect = None
 
@@ -160,6 +159,7 @@ class Photon:
     def scatterBy(self, theta, phi):
         self._er.rotateAround(self._direction, phi)
         self._direction.rotateAround(self._er, theta)
+        self._er = self._direction.getAnyOrthogonal()
 
     def interact(self):
         delta = self._weight * self.material.getAlbedo()

--- a/pytissueoptics/rayscattering/photon.py
+++ b/pytissueoptics/rayscattering/photon.py
@@ -11,7 +11,6 @@ from pytissueoptics.scene.intersection import Ray
 from pytissueoptics.scene.intersection.intersectionFinder import IntersectionFinder, Intersection
 from pytissueoptics.scene.logger import Logger, InteractionKey
 
-WORLD_LABEL = "world"
 WEIGHT_THRESHOLD = 1e-4
 MIN_ANGLE = 0.0001
 
@@ -52,9 +51,7 @@ class Photon:
 
     @property
     def solidLabel(self):
-        if not self._environment.solid:
-            return WORLD_LABEL
-        return self._environment.solid.getLabel()
+        return self._environment.solidLabel
 
     def setContext(self, environment: Environment, intersectionFinder: IntersectionFinder = None, logger: Logger = None,
                    fresnelIntersect=FresnelIntersect()):

--- a/pytissueoptics/rayscattering/tests/materials/testScatteringMaterial.py
+++ b/pytissueoptics/rayscattering/tests/materials/testScatteringMaterial.py
@@ -11,7 +11,7 @@ class TestScatteringMaterial(unittest.TestCase):
         expectedAlbedo = 2 / (2 + 8)
         self.assertEqual(expectedAlbedo, material.getAlbedo())
 
-    @patch('numpy.random.random')
+    @patch('random.random')
     def testShouldHaveScatteringDistance(self, mockRandom):
         randomDistanceRatio = 0.5
         mockRandom.return_value = randomDistanceRatio
@@ -30,7 +30,7 @@ class TestScatteringMaterial(unittest.TestCase):
         theta, phi = material.getScatteringAngles()
         self.assertEqual(0, theta)
 
-    @patch('numpy.random.random')
+    @patch('random.random')
     def testShouldHaveThetaScatteringAngleBetween0AndPi(self, mockRandom):
         mockRandom.return_value = 0
         material = ScatteringMaterial(mu_s=8, mu_a=2, g=0, n=1.4)
@@ -45,7 +45,7 @@ class TestScatteringMaterial(unittest.TestCase):
         theta, _ = material.getScatteringAngles()
         self.assertEqual(0, theta)
 
-    @patch('numpy.random.random')
+    @patch('random.random')
     def testShouldHavePhiScatteringAngleBetween0And2Pi(self, mockRandom):
         mockRandom.return_value = 0
         material = ScatteringMaterial(mu_s=8, mu_a=2, g=0, n=1.4)

--- a/pytissueoptics/rayscattering/tests/opencl/src/CLObjects.py
+++ b/pytissueoptics/rayscattering/tests/opencl/src/CLObjects.py
@@ -1,0 +1,73 @@
+import numpy as np
+from numpy.lib import recfunctions as rfn
+
+from pytissueoptics import Vector
+from pytissueoptics.rayscattering.opencl import OPENCL_AVAILABLE
+
+if OPENCL_AVAILABLE:
+    import pyopencl as cl
+else:
+    cl = None
+
+from pytissueoptics.rayscattering.opencl.buffers import CLObject
+
+
+class IntersectionCL(CLObject):
+    STRUCT_NAME = "Intersection"
+    STRUCT_DTYPE = np.dtype([("exists", cl.cltypes.uint),
+                             ("distance", cl.cltypes.float),
+                             ("position", cl.cltypes.float3),
+                             ("normal", cl.cltypes.float3),
+                             ("surfaceID", cl.cltypes.uint),
+                             ("polygonID", cl.cltypes.uint),
+                             ("distanceLeft", cl.cltypes.float),
+                             ("isSmooth", cl.cltypes.uint),
+                             ("rawNormal", cl.cltypes.float3)])
+
+    def __init__(self, distance: float = 10, position=Vector(0, 0, 0), normal=Vector(0, 0, 1),
+                 surfaceID=0, polygonID=0, distanceLeft: float = 0, **kwargs):
+        self._distance = distance
+        self._position = position
+        self._normal = normal
+        self._surfaceID = surfaceID
+        self._polygonID = polygonID
+        self._distanceLeft = distanceLeft
+
+        super().__init__(**kwargs)
+
+    def _getInitialHostBuffer(self) -> np.ndarray:
+        buffer = np.empty(1, dtype=self._dtype)
+        buffer[0]["exists"] = np.uint32(True)
+        buffer[0]["distance"] = np.float32(self._distance)
+        buffer = rfn.structured_to_unstructured(buffer)
+        buffer[0, 2:5] = self._position.array
+        buffer[0, 6:9] = self._normal.array
+        buffer = rfn.unstructured_to_structured(buffer, self._dtype)
+        buffer[0]["surfaceID"] = np.uint32(self._surfaceID)
+        buffer[0]["polygonID"] = np.uint32(self._polygonID)
+        buffer[0]["distanceLeft"] = np.float32(self._distanceLeft)
+        return buffer
+
+
+class RayCL(CLObject):
+    STRUCT_NAME = "Ray"
+    STRUCT_DTYPE = np.dtype([("origin", cl.cltypes.float4),
+                             ("direction", cl.cltypes.float4),
+                             ("length", cl.cltypes.float)])
+
+    def __init__(self, origins: np.ndarray, directions: np.ndarray, lengths: np.ndarray):
+        self._origins = origins
+        self._directions = directions
+        self._lengths = lengths
+        self._N = origins.shape[0]
+
+        super().__init__(skipDeclaration=True)
+
+    def _getInitialHostBuffer(self) -> np.ndarray:
+        buffer = np.zeros(self._N, dtype=self._dtype)
+        buffer = rfn.structured_to_unstructured(buffer)
+        buffer[:, 0:3] = self._origins
+        buffer[:, 4:7] = self._directions
+        buffer[:, 8] = self._lengths
+        buffer = rfn.unstructured_to_structured(buffer, self._dtype)
+        return buffer

--- a/pytissueoptics/rayscattering/tests/opencl/src/testCLSmoothing.py
+++ b/pytissueoptics/rayscattering/tests/opencl/src/testCLSmoothing.py
@@ -8,7 +8,7 @@ from pytissueoptics import *
 from pytissueoptics.rayscattering.opencl import OPENCL_AVAILABLE
 from pytissueoptics.rayscattering.opencl.buffers import *
 from pytissueoptics.rayscattering.opencl.config.CLConfig import OPENCL_SOURCE_DIR
-from pytissueoptics.rayscattering.tests.opencl.src.testCLIntersection import RayCL, IntersectionCL
+from pytissueoptics.rayscattering.tests.opencl.src.CLObjects import IntersectionCL, RayCL
 from pytissueoptics.scene.geometry.triangle import Triangle
 from pytissueoptics.scene.geometry.vertex import Vertex
 from pytissueoptics.rayscattering.opencl.CLProgram import CLProgram
@@ -67,8 +67,7 @@ class TestCLNormalSmoothing(unittest.TestCase):
         triangleInfo = TriangleCLInfo([0, 1, 2], self.TRIANGLE.normal)
         triangleCL = TriangleCL([triangleInfo])
         N = 1
-        intersectionCL = IntersectionCL(N)
-        intersectionCL.setResults(np.full(N, 0), np.full((N, 3), atPosition.array), np.full((N, 3), self.TRIANGLE.normal.array))
+        intersectionCL = IntersectionCL(polygonID=0, position=atPosition, normal=self.TRIANGLE.normal, skipDeclaration=True)
         rayCL = RayCL(origins=np.full((N, 3), [0, 0, 0]),
                       directions=np.full((N, 3), rayDirection.array),
                       lengths=np.full(N, 10))

--- a/pytissueoptics/rayscattering/tests/opencl/testCLPhotons.py
+++ b/pytissueoptics/rayscattering/tests/opencl/testCLPhotons.py
@@ -36,7 +36,8 @@ class TestCLPhotons(unittest.TestCase):
 
         dataPoints = logger.getDataPoints()
         totalWeightScattered = float(np.sum(dataPoints[:, 0]))
-        self.assertAlmostEqual(N, totalWeightScattered, places=2)
+        # Roulette effect will result in total weight slightly different from N.
+        self.assertAlmostEqual(N, totalWeightScattered, places=1)
 
     def testWhenPropagateInSolids_shouldLogEnergyWithCorrectInteractionKeys(self):
         N = 100

--- a/pytissueoptics/rayscattering/tests/testPhoton.py
+++ b/pytissueoptics/rayscattering/tests/testPhoton.py
@@ -6,13 +6,14 @@ from unittest.mock import patch
 from mockito import mock, when, verify
 
 from pytissueoptics.rayscattering import Photon
-from pytissueoptics.rayscattering.photon import WORLD_LABEL, WEIGHT_THRESHOLD
+from pytissueoptics.rayscattering.photon import WEIGHT_THRESHOLD
 from pytissueoptics.rayscattering.fresnel import FresnelIntersection, FresnelIntersect
 from pytissueoptics.rayscattering.materials import ScatteringMaterial
 from pytissueoptics.scene import Vector, Logger
-from pytissueoptics.scene.geometry import Environment
+from pytissueoptics.scene.geometry import Environment, Triangle, Polygon
+from pytissueoptics.scene.geometry.polygon import WORLD_LABEL
 from pytissueoptics.scene.intersection.intersectionFinder import Intersection, IntersectionFinder
-from pytissueoptics.scene.intersection.mollerTrumboreIntersect import MollerTrumboreIntersect, EPS_CORRECTION
+from pytissueoptics.scene.intersection.mollerTrumboreIntersect import MollerTrumboreIntersect
 from pytissueoptics.scene.logger import InteractionKey
 from pytissueoptics.scene.solids import Solid
 
@@ -124,27 +125,19 @@ class TestPhoton(unittest.TestCase):
         self.photon.step()
         self.assertFalse(self.photon.isAlive)
 
-    def testWhenStepWithIntersection_shouldMovePhotonABitPastIntersection(self):
-        """
-        The photon starts at z=0, and is moving in the -z direction. The intersection is at z=-8.
-        The intersection normal is in the +z direction, so the photon initially lies outside the
-        object to intersect. Therefore, we set the photon's context to be in solidOutside.
-        We expect photon to intersect at -8 and continue for a distance of EPS_CORRECTION in the
-        direction opposite to the intersection normal. In this case since the intersection normal
-        is simply +z, we expect the photon to continue towards -z and land at z = -8 - EPS_CORRECTION.
-        """
+    def testWhenStepWithIntersection_shouldMovePhotonToIntersection(self):
         distance = 8
+        intersectionPosition = self.INITIAL_POSITION + self.INITIAL_DIRECTION * distance
         intersectionFinder = self._createIntersectionFinder(distance)
-        self.photon.setContext(Environment(ScatteringMaterial(), self.solidOutside),
-                               intersectionFinder=intersectionFinder)
+        self.photon.setContext(
+            Environment(ScatteringMaterial(), self.solidOutside), intersectionFinder=intersectionFinder
+        )
 
         self.photon.step(distance + 2)
 
-        expectedDistance = distance + EPS_CORRECTION
-        self.assertVectorEqual(self.INITIAL_POSITION + self.photon.direction * expectedDistance,
-                               self.photon.position)
+        self.assertVectorEqual(intersectionPosition, self.photon.position)
 
-    def testWhenStepTooCloseToIntersectionFromOutside_shouldMovePhotonBackABitAndScatter(self):
+    def testWhenStepTooCloseToIntersection_shouldMovePhotonToIntersection(self):
         distance = 8
         rayLength = distance - 0.5 * EPS
         intersectionFinder = self._createIntersectionFinder(distance, rayLength=rayLength)
@@ -153,23 +146,8 @@ class TestPhoton(unittest.TestCase):
 
         self.photon.step(rayLength)
 
-        self.assertVectorEqual(self.INITIAL_POSITION + self.INITIAL_DIRECTION * (rayLength - EPS_CORRECTION),
-                               self.photon.position)
-        self.assertVectorNotEqual(self.INITIAL_DIRECTION, self.photon.direction)
-
-    def testWhenStepTooCloseToIntersectionFromInside_shouldMovePhotonBackABitAndScatter(self):
-        distance = 8
-        rayLength = distance - 0.5 * EPS
-        intersectionFinder = self._createIntersectionFinder(distance, rayLength=rayLength,
-                                                            normal=Vector(0, 0, -1))
-        self.photon.setContext(Environment(ScatteringMaterial(), self.solidInside),
-                               intersectionFinder=intersectionFinder)
-
-        self.photon.step(rayLength)
-
-        self.assertVectorEqual(self.INITIAL_POSITION + self.INITIAL_DIRECTION * (rayLength - EPS_CORRECTION),
-                               self.photon.position)
-        self.assertVectorNotEqual(self.INITIAL_DIRECTION, self.photon.direction)
+        self.assertVectorEqual(self.INITIAL_POSITION + self.INITIAL_DIRECTION * rayLength, self.photon.position)
+        self.assertVectorEqual(self.INITIAL_DIRECTION, self.photon.direction)
 
     def testWhenStepWithNoIntersection_shouldMovePhotonAcrossStepDistanceAndScatter(self):
         noIntersectionFinder = mock(IntersectionFinder)
@@ -205,7 +183,7 @@ class TestPhoton(unittest.TestCase):
         expectedPosition = self.INITIAL_POSITION + self.INITIAL_DIRECTION * newScatteringDistance
         self.assertVectorEqual(expectedPosition, self.photon.position)
 
-    def testWhenStepWithReflectingIntersection_shouldMovePhotonABitBackFromIntersection(self):
+    def testWhenStepWithReflectingIntersection_shouldMovePhotonToIntersection(self):
         totalDistance = 10
         intersectionDistance = 8
         intersectionFinder = self._createIntersectionFinder(intersectionDistance, rayLength=totalDistance)
@@ -216,7 +194,7 @@ class TestPhoton(unittest.TestCase):
 
         self.photon.step(totalDistance)
 
-        expectedPosition = self.INITIAL_POSITION + self.INITIAL_DIRECTION * (intersectionDistance - EPS_CORRECTION)
+        expectedPosition = self.INITIAL_POSITION + self.INITIAL_DIRECTION * intersectionDistance
         self.assertVectorEqual(expectedPosition, self.photon.position)
 
     def testWhenStepWithReflectingIntersection_shouldReturnDistanceLeft(self):
@@ -242,7 +220,7 @@ class TestPhoton(unittest.TestCase):
 
         self.assertEqual(nextMaterial, self.photon.material)
 
-    def testWhenStepWithRefractingIntersection_shouldMovePhotonABitAfterIntersection(self):
+    def testWhenStepWithRefractingIntersection_shouldMovePhotonToIntersection(self):
         scatteringDistance = 10
         intersectionDistance = 8
         material = ScatteringMaterial(mu_s=2, mu_a=1, g=0.8)
@@ -253,7 +231,7 @@ class TestPhoton(unittest.TestCase):
 
         self.photon.step(scatteringDistance)
 
-        expectedPosition = self.INITIAL_POSITION + self.INITIAL_DIRECTION * (intersectionDistance + EPS_CORRECTION)
+        expectedPosition = self.INITIAL_POSITION + self.INITIAL_DIRECTION * intersectionDistance
         self.assertVectorEqual(expectedPosition, self.photon.position)
 
     def testWhenStepWithRefractingIntersection_shouldReturnDistanceLeftInNextMaterial(self):
@@ -427,17 +405,15 @@ class TestPhoton(unittest.TestCase):
         self.assertNotAlmostEqual(v1.z, v2.z)
 
     def _createIntersectionFinder(self, intersectionDistance=10, rayLength=None, normal=Vector(0, 0, 1)):
-        isTooClose = False
         if rayLength is None:
             rayLength = intersectionDistance + 2
-        if intersectionDistance and rayLength:
-            if abs(intersectionDistance - rayLength) < EPS:
-                isTooClose = True
-        intersection = Intersection(intersectionDistance, position=Vector(), normal=normal,
+        position = self.INITIAL_POSITION + self.INITIAL_DIRECTION * intersectionDistance
+        polygon = mock(Polygon)
+        polygon.vertices = []
+        intersection = Intersection(intersectionDistance, position=position, polygon=polygon, normal=normal,
                                     insideEnvironment=Environment(ScatteringMaterial(), self.solidInside),
                                     outsideEnvironment=Environment(ScatteringMaterial(), self.solidOutside),
-                                    surfaceLabel=self.SURFACE_LABEL, distanceLeft=rayLength-intersectionDistance,
-                                    isTooClose=isTooClose)
+                                    surfaceLabel=self.SURFACE_LABEL, distanceLeft=rayLength-intersectionDistance)
         intersectionFinder = mock(IntersectionFinder)
         when(intersectionFinder).findIntersection(...).thenReturn(intersection)
         return intersectionFinder

--- a/pytissueoptics/rayscattering/tests/testPhoton.py
+++ b/pytissueoptics/rayscattering/tests/testPhoton.py
@@ -17,7 +17,7 @@ from pytissueoptics.scene.logger import InteractionKey
 from pytissueoptics.scene.solids import Solid
 
 
-EPS = MollerTrumboreIntersect.EPS
+EPS = MollerTrumboreIntersect.EPS_CATCH
 
 
 class TestPhoton(unittest.TestCase):
@@ -230,7 +230,7 @@ class TestPhoton(unittest.TestCase):
 
         distanceLeft = self.photon.step(totalDistance)
 
-        expectedDistanceLeft = totalDistance - intersectionDistance - EPS_CORRECTION
+        expectedDistanceLeft = totalDistance - intersectionDistance
         self.assertAlmostEqual(expectedDistanceLeft, distanceLeft)
 
     def testWhenStepWithRefractingIntersection_shouldUpdatePhotonMaterialToNextMaterial(self):
@@ -267,7 +267,6 @@ class TestPhoton(unittest.TestCase):
         distanceLeft = self.photon.step(scatteringDistance)
 
         expectedDistanceLeft = (scatteringDistance - intersectionDistance) * material.mu_t / nextMaterial.mu_t
-        expectedDistanceLeft -= EPS_CORRECTION
         self.assertAlmostEqual(expectedDistanceLeft, distanceLeft)
 
     def testWhenStepWithRefractingIntersectionToVacuum_shouldReturnInfiniteDistanceLeft(self):

--- a/pytissueoptics/scene/geometry/polygon.py
+++ b/pytissueoptics/scene/geometry/polygon.py
@@ -4,11 +4,19 @@ from typing import List
 from pytissueoptics.scene.geometry import Vector, Vertex
 from pytissueoptics.scene.geometry import BoundingBox
 
+WORLD_LABEL = "world"
+
 
 @dataclass
 class Environment:
     material: ...
     solid: 'Solid' = None
+
+    @property
+    def solidLabel(self) -> str:
+        if self.solid:
+            return self.solid.getLabel()
+        return WORLD_LABEL
 
 
 class Polygon:

--- a/pytissueoptics/scene/geometry/vector.py
+++ b/pytissueoptics/scene/geometry/vector.py
@@ -120,6 +120,7 @@ class Vector:
             uz = -sint*cosp*temp + self._z*cost
 
         self.update(ux, uy, uz)
+        self.normalize()
 
     def rotateAround(self, unitAxis: 'Vector', theta: float):
         """

--- a/pytissueoptics/scene/geometry/vector.py
+++ b/pytissueoptics/scene/geometry/vector.py
@@ -1,7 +1,5 @@
 import math
 
-COS_ZERO = 1 - 1e-12
-
 
 class Vector:
     """
@@ -98,35 +96,23 @@ class Vector:
     def copy(self) -> 'Vector':
         return Vector(self._x, self._y, self._z)
 
-    def spin(self, theta: float, phi: float):
-        """ In spherical coordinates. Taken directly from MCML code. """
-        cosp = math.cos(phi)
-        if phi < math.pi:
-            sinp = math.sqrt(1 - cosp*cosp)
-        else:
-            sinp = -math.sqrt(1 - cosp*cosp)
-
-        cost = math.cos(theta)
-        sint = math.sqrt(1 - cost*cost)
-
-        if abs(self._z) > COS_ZERO:
-            ux = sint*cosp
-            uy = sint*sinp
-            uz = cost * (1 if self._z >= 0 else -1)
-        else:
-            temp = math.sqrt(1 - self._z*self._z)
-            ux = sint*(self._x*self._z*cosp - self._y*sinp) / temp + self._x*cost
-            uy = sint*(self._y*self._z*cosp + self._x*sinp) / temp + self._y*cost
-            uz = -sint*cosp*temp + self._z*cost
-
-        self.update(ux, uy, uz)
-        self.normalize()
-
     def rotateAround(self, unitAxis: 'Vector', theta: float):
         """
         Rotate the vector around `unitAxis` by `theta` radians. Assumes the axis to be a unit vector.
         Uses Rodrigues' rotation formula.
         """
+        # This is the most expensive (and most common)
+        # operation when performing Monte Carlo in tissue
+        # (15% of time spent here). It is difficult to optimize without
+        # making it even less readable than it currently is
+        # http://en.wikipedia.org/wiki/Rotation_matrix
+        #
+        # Several options were tried in the past such as
+        # external not-so-portable C library, unreadable
+        # shortcuts, sine and cosine lookup tables, etc...
+        # and the performance gain was minimal (<20%).
+        # For now, this is the best, most readable solution.
+
         cost = math.cos(theta)
         sint = math.sin(theta)
         one_cost = 1 - cost

--- a/pytissueoptics/scene/geometry/vector.py
+++ b/pytissueoptics/scene/geometry/vector.py
@@ -1,5 +1,7 @@
 import math
 
+COS_ZERO = 1 - 1e-12
+
 
 class Vector:
     """
@@ -96,22 +98,34 @@ class Vector:
     def copy(self) -> 'Vector':
         return Vector(self._x, self._y, self._z)
 
+    def spin(self, theta: float, phi: float):
+        """ In spherical coordinates. Taken directly from MCML code. """
+        cosp = math.cos(phi)
+        if phi < math.pi:
+            sinp = math.sqrt(1 - cosp*cosp)
+        else:
+            sinp = -math.sqrt(1 - cosp*cosp)
+
+        cost = math.cos(theta)
+        sint = math.sqrt(1 - cost*cost)
+
+        if abs(self._z) > COS_ZERO:
+            ux = sint*cosp
+            uy = sint*sinp
+            uz = cost * (1 if self._z >= 0 else -1)
+        else:
+            temp = math.sqrt(1 - self._z*self._z)
+            ux = sint*(self._x*self._z*cosp - self._y*sinp) / temp + self._x*cost
+            uy = sint*(self._y*self._z*cosp + self._x*sinp) / temp + self._y*cost
+            uz = -sint*cosp*temp + self._z*cost
+
+        self.update(ux, uy, uz)
+
     def rotateAround(self, unitAxis: 'Vector', theta: float):
         """
         Rotate the vector around `unitAxis` by `theta` radians. Assumes the axis to be a unit vector.
+        Uses Rodrigues' rotation formula.
         """
-        # This is the most expensive (and most common)
-        # operation when performing Monte Carlo in tissue
-        # (15% of time spent here). It is difficult to optimize without
-        # making it even less readable than it currently is
-        # http://en.wikipedia.org/wiki/Rotation_matrix
-        #
-        # Several options were tried in the past such as
-        # external not-so-portable C library, unreadable
-        # shortcuts, sine and cosine lookup tables, etc...
-        # and the performance gain was minimal (<20%).
-        # For now, this is the best, most readable solution.
-
         cost = math.cos(theta)
         sint = math.sin(theta)
         one_cost = 1 - cost

--- a/pytissueoptics/scene/geometry/vector.py
+++ b/pytissueoptics/scene/geometry/vector.py
@@ -27,6 +27,9 @@ class Vector:
     def __repr__(self):
         return f"<Vector>:({self._x}, {self._y}, {self._z})"
 
+    def __iter__(self):
+        return iter((self._x, self._y, self._z))
+
     def __eq__(self, other: 'Vector'):
         tol = 1e-5
         if math.isclose(other._x, self._x, abs_tol=tol) and math.isclose(other._y, self._y, abs_tol=tol) and math.isclose(other._z, self._z, abs_tol=tol):

--- a/pytissueoptics/scene/intersection/intersectionFinder.py
+++ b/pytissueoptics/scene/intersection/intersectionFinder.py
@@ -23,7 +23,8 @@ class Intersection:
     outsideEnvironment: Environment = None
     surfaceLabel: str = None
     distanceLeft: float = None
-    isTooClose: bool = False
+    isSmooth: bool = False
+    rawNormal: Vector = None
 
 
 class IntersectionFinder:
@@ -64,20 +65,24 @@ class IntersectionFinder:
         if not intersection:
             return None
 
-        smoothNormal = shader.getSmoothNormal(intersection.polygon, intersection.position)
-
-        # If the resulting smooth normal changes the sign of the dot product with the ray direction, do not smooth.
-        if smoothNormal.dot(ray.direction) * intersection.polygon.normal.dot(ray.direction) < 0:
-            smoothNormal = intersection.polygon.normal
-
-        intersection.normal = smoothNormal
         intersection.insideEnvironment = intersection.polygon.insideEnvironment
         intersection.outsideEnvironment = intersection.polygon.outsideEnvironment
         intersection.surfaceLabel = intersection.polygon.surfaceLabel
+        intersection.rawNormal = intersection.polygon.normal
 
         if ray.length is not None:
             intersection.distanceLeft = ray.length - intersection.distance
 
+        smoothNormal = shader.getSmoothNormal(intersection.polygon, intersection.position)
+
+        # If the resulting smooth normal changes the sign of the dot product with the ray direction, do not smooth.
+        if smoothNormal.dot(ray.direction) * intersection.polygon.normal.dot(ray.direction) < 0:
+            intersection.normal = intersection.polygon.normal
+            intersection.isSmooth = False
+            return intersection
+
+        intersection.normal = smoothNormal
+        intersection.isSmooth = True
         return intersection
 
 

--- a/pytissueoptics/scene/intersection/intersectionFinder.py
+++ b/pytissueoptics/scene/intersection/intersectionFinder.py
@@ -96,11 +96,8 @@ class SimpleIntersectionFinder(IntersectionFinder):
                 possible, and we simply set the bbox intersection distance to zero.
         2. Sort these solid candidates by bbox intersection distance.
         3. For each solid, find the closest polygon intersection.
-            3.1 If a polygon intersection is found for a given solid candidate, then we return this intersection point
-            without testing the other solid candidates since they are ordered by distance.
-            N.B.: Except for the case of multiple contained solids where it is not possible to order them in a
-            meaningful way, so in this case we need to test all of them (candidate distance is zero) before
-            returning the closest intersection found.
+            If the solid bbox distance is greater than the closest intersection distance, then we can stop testing since
+            they are ordered by distance. Note that bbox distance is zero if the ray starts inside.
         """
         bboxIntersections = self._findBBoxIntersectingSolids(ray, currentSolidLabel)
         bboxIntersections.sort(key=lambda x: x[0])
@@ -108,8 +105,7 @@ class SimpleIntersectionFinder(IntersectionFinder):
         closestDistance = sys.maxsize
         closestIntersection = None
         for i, (distance, solid) in enumerate(bboxIntersections):
-            contained = distance == 0
-            if not contained and closestIntersection:
+            if distance > closestDistance:
                 break
             intersection = self._findClosestPolygonIntersection(ray, solid.getPolygons(), currentSolidLabel)
             if intersection and intersection.distance < closestDistance:

--- a/pytissueoptics/scene/intersection/intersectionFinder.py
+++ b/pytissueoptics/scene/intersection/intersectionFinder.py
@@ -32,19 +32,28 @@ class IntersectionFinder:
         self._polygonIntersect = MollerTrumboreIntersect()
         self._boxIntersect = GemsBoxIntersect()
 
-    def findIntersection(self, ray: Ray) -> Optional[Intersection]:
+    def findIntersection(self, ray: Ray, currentSolidLabel: str) -> Optional[Intersection]:
         raise NotImplementedError
 
-    def _findClosestPolygonIntersection(self, ray: Ray, polygons: List[Polygon]) -> Optional[Intersection]:
+    def _findClosestPolygonIntersection(
+        self, ray: Ray, polygons: List[Polygon], currentSolidLabel: str
+    ) -> Optional[Intersection]:
         closestIntersection = Intersection(sys.maxsize)
         for polygon in polygons:
+            # Skip intersection test if the ray is heading towards its current solid
+            # (possible because of the epsilon catch zone in our Moller Trumbore intersect).
+            isGoingInside = ray.direction.dot(polygon.normal) < 0
+            nextSolid = polygon.insideEnvironment.solid if isGoingInside else polygon.outsideEnvironment.solid
+            nextLabel = 'world' if nextSolid is None else nextSolid.getLabel()
+            if nextLabel == currentSolidLabel:
+                continue
+
             intersectionPoint = self._polygonIntersect.getIntersection(ray, polygon)
             if not intersectionPoint:
                 continue
             distance = (intersectionPoint - ray.origin).getNorm()
             if distance < closestIntersection.distance:
                 closestIntersection = Intersection(distance, intersectionPoint, polygon)
-                closestIntersection.isTooClose = ray.isTooClose
 
         if closestIntersection.distance == sys.maxsize:
             return None
@@ -73,7 +82,7 @@ class IntersectionFinder:
 
 
 class SimpleIntersectionFinder(IntersectionFinder):
-    def findIntersection(self, ray: Ray) -> Optional[Intersection]:
+    def findIntersection(self, ray: Ray, currentSolidLabel: str) -> Optional[Intersection]:
         """
         Find the closest intersection between a ray and the scene.
 
@@ -88,7 +97,7 @@ class SimpleIntersectionFinder(IntersectionFinder):
             meaningful way, so in this case we need to test all of them (candidate distance is zero) before
             returning the closest intersection found.
         """
-        bboxIntersections = self._findBBoxIntersectingSolids(ray)
+        bboxIntersections = self._findBBoxIntersectingSolids(ray, currentSolidLabel)
         bboxIntersections.sort(key=lambda x: x[0])
 
         closestDistance = sys.maxsize
@@ -97,20 +106,23 @@ class SimpleIntersectionFinder(IntersectionFinder):
             contained = distance == 0
             if not contained and closestIntersection:
                 break
-            intersection = self._findClosestPolygonIntersection(ray, solid.getPolygons())
+            intersection = self._findClosestPolygonIntersection(ray, solid.getPolygons(), currentSolidLabel)
             if intersection and intersection.distance < closestDistance:
                 closestDistance = intersection.distance
                 closestIntersection = intersection
 
         return self._composeIntersection(ray, closestIntersection)
 
-    def _findBBoxIntersectingSolids(self, ray) -> Optional[List[Tuple[float, Solid]]]:
+    def _findBBoxIntersectingSolids(self, ray: Ray, currentSolidLabel: str) -> Optional[List[Tuple[float, Solid]]]:
         """ We need to handle the special case where ray starts inside bbox. The Box Intersect will not compute
         the intersection for this case and will instead return ray.origin. When that happens, distance will be 0,
         and we continue to check for possibly other contained solids. """
         solidCandidates = []
         for solid in self._scene.solids:
-            bboxIntersectionPoint = self._boxIntersect.getIntersection(ray, solid.bbox)
+            if solid.getLabel() == currentSolidLabel:
+                bboxIntersectionPoint = ray.origin
+            else:
+                bboxIntersectionPoint = self._boxIntersect.getIntersection(ray, solid.bbox)
             if not bboxIntersectionPoint:
                 continue
             distance = (bboxIntersectionPoint - ray.origin).getNorm()
@@ -124,13 +136,15 @@ class FastIntersectionFinder(IntersectionFinder):
         self._partition = SpacePartition(self._scene.getBoundingBox(), self._scene.getPolygons(), constructor,
                                          maxDepth, minLeafSize)
 
-    def findIntersection(self, ray: Ray) -> Optional[Intersection]:
+    def findIntersection(self, ray: Ray, currentSolidLabel: str) -> Optional[Intersection]:
+        self._currentSolidLabel = currentSolidLabel
         intersection = self._findIntersection(ray, self._partition.root)
         return self._composeIntersection(ray, intersection)
 
     def _findIntersection(self, ray: Ray, node: Node, closestDistance=sys.maxsize) -> Optional[Intersection]:
+        # TODO: implement a way to test triangles that are close behind the ray origin.
         if node.isLeaf:
-            intersection = self._findClosestPolygonIntersection(ray, node.polygons)
+            intersection = self._findClosestPolygonIntersection(ray, node.polygons, self._currentSolidLabel)
             return intersection
 
         if not self._nodeIsWorthExploring(ray, node, closestDistance):

--- a/pytissueoptics/scene/intersection/intersectionFinder.py
+++ b/pytissueoptics/scene/intersection/intersectionFinder.py
@@ -43,17 +43,23 @@ class IntersectionFinder:
         minSameSolidDistance = -sys.maxsize
 
         for polygon in polygons:
+            # When an interface joins a side surface, an outside photon could try to intersect with the interface.
+            #  This is not allowed, so we skip these tests (where surface environments dont match the photon).
+            insideLabel = polygon.insideEnvironment.solidLabel
+            outsideLabel = polygon.outsideEnvironment.solidLabel
+            if insideLabel != currentSolidLabel and outsideLabel != currentSolidLabel:
+                continue
+
             intersectionPoint = self._polygonIntersect.getIntersection(ray, polygon)
             if not intersectionPoint:
                 continue
             distance = (intersectionPoint - ray.origin).getNorm()
 
             # Discard intersection result if the ray is heading towards its current solid
-            # (possible because of the epsilon catch zone in our Moller Trumbore intersect).
+            # (possible because of the epsilon catch zone in our Moller-Trumbore intersect).
             isGoingInside = ray.direction.dot(polygon.normal) < 0
-            nextSolid = polygon.insideEnvironment.solid if isGoingInside else polygon.outsideEnvironment.solid
-            nextLabel = 'world' if nextSolid is None else nextSolid.getLabel()
-            if nextLabel == currentSolidLabel:
+            nextSolidLabel = insideLabel if isGoingInside else outsideLabel
+            if nextSolidLabel == currentSolidLabel:
                 minSameSolidDistance = max(minSameSolidDistance, distance)
                 continue
 

--- a/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
+++ b/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
@@ -8,7 +8,7 @@ EPS_CORRECTION = 0.0005
 
 
 class MollerTrumboreIntersect:
-    EPS = 0.00001
+    EPS_CATCH = 0.000001
     EPS_PARALLEL = 0.00001
     EPS_SIDE = 0.000001
 
@@ -44,6 +44,8 @@ class MollerTrumboreIntersect:
         tVector = ray.origin - v1
         u = tVector.dot(pVector) * inverseDeterminant
         if u < -self.EPS_SIDE or u > 1.:
+            # EPS_SIDE is used to make the triangle a bit larger than it is
+            # to be sure a ray could not sneak between two triangles.
             return None
 
         qVector = tVector.cross(edgeA)
@@ -51,21 +53,26 @@ class MollerTrumboreIntersect:
         if v < -self.EPS_SIDE or u + v > 1.:
             return None
 
+        # Distance to intersection point
         t = edgeB.dot(qVector) * inverseDeterminant
-        if t < 0.:
-            return None
-
-        if ray.length is None:
+        if t > 0 and (ray.length > t or ray.length is None):
+            # Case 1: Trivial case. Intersects.
             return ray.origin + ray.direction * t
 
-        if t > (ray.length + self.EPS):
-            # No intersection, it's too far away
-            return None
-        elif t > ray.length:
-            # Just a bit too far away. There is no intersection, but we cannot accept ray to land here.
-            ray.isTooClose = True
+        # Next we need to check if the intersection is inside the epsilon catch zone (forward or backward).
+        # Note that this mechanic only works when same-solid intersections are ignored before calling this function.
+        dt = t - ray.length
+        dt_T = abs(triangle.normal.dot(ray.direction) * dt)
+        if t > ray.length and dt_T < self.EPS_CATCH:
+            # Case 2: Forward epsilon catch. Ray ends close to the triangle, so we intersect at the ray's end.
+            return ray.origin + ray.direction * ray.length
+        if t < 0 and dt_T < self.EPS_CATCH:
+            # Case 3: Backward epsilon catch. Ray starts close to the triangle, so we intersect at the origin.
+            # This requires the intersector to always test triangles (or at least, close ones) of the origin solid.
+            return ray.origin
 
-        return ray.origin + ray.direction * t
+        # Case 4: No intersection.
+        return None
 
     def _getQuadIntersection(self, ray: Ray, quad: Quad) -> Optional[Vector]:
         v1, v2, v3, v4 = quad.vertices

--- a/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
+++ b/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
@@ -57,9 +57,11 @@ class MollerTrumboreIntersect:
 
         # Distance to intersection point
         t = edgeB.dot(qVector) * inverseDeterminant
+        hitPoint = ray.origin + ray.direction * t
+
         if t > 0 and (ray.length >= t or ray.length is None):
             # Case 1: Trivial case. Intersects.
-            return ray.origin + ray.direction * t
+            return hitPoint
 
         # Next we need to check if the intersection is inside the epsilon catch zone (forward or backward).
         # Note that this mechanic only works when same-solid intersections are ignored before calling this function.
@@ -69,8 +71,8 @@ class MollerTrumboreIntersect:
             dt = t - ray.length
         dt_T = abs(triangle.normal.dot(ray.direction) * dt)
         if t > ray.length and dt_T < self.EPS_CATCH:
-            # Case 2: Forward epsilon catch. Ray ends close to the triangle, so we intersect at the ray's end.
-            return ray.origin + ray.direction * ray.length
+            # Case 2: Forward epsilon catch. Ray ends too close to the triangle, so we intersect.
+            return hitPoint
         if t <= 0 and dt_T < self.EPS_CATCH:
             # Case 3: Backward epsilon catch. Ray starts close to the triangle, so we intersect at the origin.
             # This requires the intersector to always test triangles (or at least, close ones) of the origin solid.

--- a/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
+++ b/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
@@ -69,7 +69,7 @@ class MollerTrumboreIntersect:
             correctionDirection = v1 + v2 + v3 - hitPoint * 3
             hitPoint += correctionDirection * 2 * error
 
-        if t >= 0 and (ray.length >= t or ray.length is None):
+        if t >= 0 and (ray.length is None or ray.length >= t):
             # Case 1: Trivial case. Intersects.
             return hitPoint
 
@@ -81,7 +81,7 @@ class MollerTrumboreIntersect:
             dt = t - ray.length
         dt_T = abs(triangle.normal.dot(ray.direction) * dt)
 
-        if t > ray.length and dt_T < self.EPS_CATCH:
+        if ray.length and t > ray.length and dt_T < self.EPS_CATCH:
             # Case 2: Forward epsilon catch. Ray ends too close to the triangle, so we intersect.
             return hitPoint
 

--- a/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
+++ b/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
@@ -6,6 +6,7 @@ from pytissueoptics.scene.intersection import Ray
 
 class MollerTrumboreIntersect:
     EPS_CATCH = 1e-7
+    EPS_BACK_CATCH = 2e-6
     EPS_PARALLEL = 1e-6
     EPS_SIDE = 3e-6
     EPS = 1e-7
@@ -81,25 +82,15 @@ class MollerTrumboreIntersect:
         else:
             dt = t - ray.length
         dt_T = abs(triangle.normal.dot(ray.direction) * dt)
+
         if t > ray.length and dt_T < self.EPS_CATCH:
             # Case 2: Forward epsilon catch. Ray ends too close to the triangle, so we intersect.
             return hitPoint
-        if t <= 0 and dt_T < self.EPS_CATCH:
-            # Case 3: Backward epsilon catch. Ray starts close to the triangle, so we intersect at the origin.
+
+        if t < 0 and (t > -self.EPS_BACK_CATCH or dt_T < self.EPS_CATCH):
+            # Case 3: Backward epsilon catch. Ray starts too close to the triangle, so we intersect.
             # This requires the intersector to always test triangles (or at least, close ones) of the origin solid.
-
-            # Do not catch if the origin lies outside the triangle (intersection test using triangle normal).
-            pVector = triangle.normal.cross(edgeB)
-            determinant = edgeA.dot(pVector)
-            inverseDeterminant = 1. / determinant
-            u = tVector.dot(pVector) * inverseDeterminant
-            if u < 0 or u > 1:
-                return None
-            v = triangle.normal.dot(qVector) * inverseDeterminant
-            if v < 0 or u + v > 1:
-                return None
-
-            return ray.origin
+            return hitPoint
 
         # Case 4: No intersection.
         return None

--- a/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
+++ b/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
@@ -55,7 +55,7 @@ class MollerTrumboreIntersect:
 
         # Distance to intersection point
         t = edgeB.dot(qVector) * inverseDeterminant
-        if t > 0 and (ray.length > t or ray.length is None):
+        if t > 0 and (ray.length >= t or ray.length is None):
             # Case 1: Trivial case. Intersects.
             return ray.origin + ray.direction * t
 

--- a/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
+++ b/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
@@ -4,12 +4,12 @@ from pytissueoptics.scene.geometry import Vector, Triangle, Quad, Polygon
 from pytissueoptics.scene.intersection import Ray
 
 
-EPS_CORRECTION = 0.0005
+EPS_CORRECTION = 0.0  # TODO: remove
 
 
 class MollerTrumboreIntersect:
-    EPS_CATCH = 0.000001
-    EPS_PARALLEL = 0.00001
+    EPS_CATCH = 0.00001
+    EPS_PARALLEL = 0.000001
     EPS_SIDE = 0.000001
 
     def getIntersection(self, ray: Ray, polygon: Union[Triangle, Quad, Polygon]) -> Optional[Vector]:
@@ -61,7 +61,10 @@ class MollerTrumboreIntersect:
 
         # Next we need to check if the intersection is inside the epsilon catch zone (forward or backward).
         # Note that this mechanic only works when same-solid intersections are ignored before calling this function.
-        dt = t - ray.length
+        if t <= 0:
+            dt = t
+        else:
+            dt = t - ray.length
         dt_T = abs(triangle.normal.dot(ray.direction) * dt)
         if t > ray.length and dt_T < self.EPS_CATCH:
             # Case 2: Forward epsilon catch. Ray ends close to the triangle, so we intersect at the ray's end.

--- a/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
+++ b/pytissueoptics/scene/intersection/mollerTrumboreIntersect.py
@@ -25,11 +25,9 @@ class MollerTrumboreIntersect:
         Modified to support rays with finite length:
             A. If the intersection is too far away, do not intersect.
             B. (Forward catch) If the intersection is just a bit too far away, such that the resulting shortest distance
-                to surface is under epsilon, we must intersect already to prevent floating point errors in the next
+                to surface is under epsilon, we must intersect to prevent floating point errors in the next
                 intersection search.
-            C. (Backward catch) If, after a forward catch, the photon attempts to scatter back (inside epsilon region)
-                before actually crossing the surface, we must trigger an intersection event (at the origin). Ignore if
-                the origin does not lie over the triangle (meaning that the photon already crossed another surface).
+            C. (Backward catch) If the photon attempts to scatter back before actually crossing the surface, we must trigger an intersection event.
         """
         v1, v2, v3 = triangle.vertices
         edgeA = v2 - v1

--- a/pytissueoptics/scene/intersection/ray.py
+++ b/pytissueoptics/scene/intersection/ray.py
@@ -8,8 +8,6 @@ class Ray:
         self._direction.normalize()
         self._length = length
 
-        self.isTooClose = False
-
     @property
     def origin(self):
         return self._origin

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -37,6 +37,7 @@ class Solid:
         self._resetPolygonsCentroids()
 
         self._smoothing = False
+        self._setVertexNormals()
         if smooth:
             self.smooth()
 
@@ -281,7 +282,10 @@ class Solid:
         be changed by overwriting the signature with a specific surfaceLabel in
         another solid implementation and calling super().smooth(surfaceLabel).
         """
-        self._smoothing = True
+        self._setVertexNormals(surfaceLabel, smooth=True, reset=reset)
+
+    def _setVertexNormals(self, surfaceLabel: str = None, smooth=False, reset=True):
+        self._smoothing = smooth
         if reset:
             for vertex in self.vertices:
                 vertex.normal = None
@@ -289,7 +293,7 @@ class Solid:
         polygons = self.getPolygons(surfaceLabel)
 
         for polygon in polygons:
-            polygon.toSmooth = True
+            polygon.toSmooth = smooth
             for vertex in polygon.vertices:
                 if vertex.normal:
                     vertex.normal += polygon.normal

--- a/pytissueoptics/scene/tests/intersection/testPolygonIntersect.py
+++ b/pytissueoptics/scene/tests/intersection/testPolygonIntersect.py
@@ -25,7 +25,6 @@ class TestAnyPolygonIntersect(unittest.TestCase):
             self.assertEqual(0.45, intersection.x)
             self.assertEqual(0.25, intersection.y)
             self.assertEqual(0.0, intersection.z)
-            self.assertFalse(ray.isTooClose)
 
     def testGivenNonIntersectingRayAndPolygon_shouldReturnNone(self):
         rayOrigin = Vector(0.25, 0.25, 1)
@@ -85,16 +84,6 @@ class TestAnyPolygonIntersect(unittest.TestCase):
             self.assertEqual(0.25, intersection.y)
             self.assertEqual(0.0, intersection.z)
 
-    def testGivenRayLandsInEpsilonRegionBeforePolygon_shouldLabelTheRayAsTooCloseForFurtherProcessing(self):
-        rayOrigin = Vector(0.25, 0.25, 2)
-        rayDirection = Vector(0, 0, -1)
-        rayDirection.normalize()
-        ray = Ray(rayOrigin, rayDirection, length=2 - MollerTrumboreIntersect.EPS_CATCH * 0.9)
-
-        for poly in ([self.triangle, self.quad, self.polygon]):
-            _ = self.intersectStrategy.getIntersection(ray, poly)
-            self.assertTrue(ray.isTooClose)
-
     def testGivenRayLandsBeforeEpsilonRegionOfPolygon_shouldReturnNone(self):
         rayOrigin = Vector(0.25, 0.25, 2)
         rayDirection = Vector(0, 0, -1)
@@ -103,6 +92,4 @@ class TestAnyPolygonIntersect(unittest.TestCase):
 
         for poly in ([self.triangle, self.quad, self.polygon]):
             intersection = self.intersectStrategy.getIntersection(ray, poly)
-
             self.assertIsNone(intersection)
-            self.assertFalse(ray.isTooClose)

--- a/pytissueoptics/scene/tests/intersection/testPolygonIntersect.py
+++ b/pytissueoptics/scene/tests/intersection/testPolygonIntersect.py
@@ -75,7 +75,7 @@ class TestAnyPolygonIntersect(unittest.TestCase):
         rayOrigin = Vector(0.25, 0.25, 2)
         rayDirection = Vector(0, 0, -1)
         rayDirection.normalize()
-        ray = Ray(rayOrigin, rayDirection, length=2 - MollerTrumboreIntersect.EPS / 2)
+        ray = Ray(rayOrigin, rayDirection, length=2 - MollerTrumboreIntersect.EPS_CATCH / 2)
 
         for poly in ([self.triangle, self.quad, self.polygon]):
             intersection = self.intersectStrategy.getIntersection(ray, poly)
@@ -89,7 +89,7 @@ class TestAnyPolygonIntersect(unittest.TestCase):
         rayOrigin = Vector(0.25, 0.25, 2)
         rayDirection = Vector(0, 0, -1)
         rayDirection.normalize()
-        ray = Ray(rayOrigin, rayDirection, length=2 - MollerTrumboreIntersect.EPS * 0.9)
+        ray = Ray(rayOrigin, rayDirection, length=2 - MollerTrumboreIntersect.EPS_CATCH * 0.9)
 
         for poly in ([self.triangle, self.quad, self.polygon]):
             _ = self.intersectStrategy.getIntersection(ray, poly)
@@ -99,7 +99,7 @@ class TestAnyPolygonIntersect(unittest.TestCase):
         rayOrigin = Vector(0.25, 0.25, 2)
         rayDirection = Vector(0, 0, -1)
         rayDirection.normalize()
-        ray = Ray(rayOrigin, rayDirection, length=2 - MollerTrumboreIntersect.EPS * 1.1)
+        ray = Ray(rayOrigin, rayDirection, length=2 - MollerTrumboreIntersect.EPS_CATCH * 1.1)
 
         for poly in ([self.triangle, self.quad, self.polygon]):
             intersection = self.intersectStrategy.getIntersection(ray, poly)

--- a/pytissueoptics/scene/tests/solids/testSolid.py
+++ b/pytissueoptics/scene/tests/solids/testSolid.py
@@ -218,6 +218,7 @@ class TestSolid(unittest.TestCase):
     @staticmethod
     def createPolygonMock() -> Polygon:
         polygon = mock(Polygon)
+        polygon.vertices = []
         when(polygon).resetNormal().thenReturn()
         when(polygon).resetBoundingBox().thenReturn()
         when(polygon).resetCentroid().thenReturn()


### PR DESCRIPTION
Changes most of the intersection behavior at the smaller scale (around floating point limit) to address many issues like photons leaving a geometry without intersecting, photons getting stuck (refraction loop), photons surfing (reflection loop) and general energy conservation issues.

Other aspects of the propagation and large-scale intersection logic were also fixed along the way.

Extensively tested in extreme cases with small structures and very low scattering distances (up to mu_t around 1000). 

**Main changes**
- New floating-point safety mecanisms for ray-polygon intersections. 
  - Do not freely push photons away from intersection surfaces after Fresnel, unless precisely landing on a vertex or an edge.
  - Move photon to intersection surface and intersect if it is about to land too close (forward catch), including parallel paths, and correctly carrying over the negative distance left. Similarly, intersect photons trying to leave their current environment when found close behind (backward catch) and there are no same-environment intersections close upfront or surface overlaps. 
  - Prevent invalid intersection tests like rays entering a layer stack through an interface. 
  - Temporarily make the polygons slightly larger to prevent rays sneaking in-between.
- Fixed smoothing algorithm to prevent refracted rays from staying inside their previous environment (and vice versa for reflected rays).
- Fix discrepancies in scattering angles by refreshing the orthogonal vector.
