### PR TITLE
Setup tests CI

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,58 @@
+name: Test all platforms
+
+on: [ pull_request, workflow_dispatch ]
+
+jobs:
+  test:
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ ubuntu-latest, macos-13, macos-latest, windows-latest ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12", "3.13" ]
+
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Linux packages for Qt5/Qt6 support and start Xvfb
+        if: runner.os == 'Linux'
+        uses: pyvista/setup-headless-display-action@v3
+        with:
+          qt: true
+
+      - name: Linux OpenCL support
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pocl-opencl-icd ocl-icd-opencl-dev gcc clinfo
+          clinfo
+
+      - name : Windows OpenCL support
+        if: runner.os == 'Windows'
+        run: |
+          choco install opencl-intel-cpu-runtime --no-progress --yes
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install setuptools>=40.8.0 wheel pytest
+          python -m pip install .
+          python -m pip freeze --all
+
+      - name: Validate OpenCL
+        if: matrix.os != 'macos-latest'  # no OpenCL device in macOS runners since macos-14
+        run: |
+          python -c "from pytissueoptics.rayscattering.opencl import OPENCL_OK; assert OPENCL_OK"
+
+      - name: Run tests
+        env:
+          PTO_CI_MODE: 1
+        run: |
+          python -m pytest -v

--- a/pytissueoptics/rayscattering/opencl/config/CLConfig.py
+++ b/pytissueoptics/rayscattering/opencl/config/CLConfig.py
@@ -178,6 +178,12 @@ class CLConfig:
         with open(OPENCL_CONFIG_PATH, "r") as f:
             self._config = json.load(f)
 
+        if os.getenv("PTO_CI_MODE", "0") == "1":
+            warnings.warn("Using default OpenCL configuration for CI mode.")
+            self.DEVICE_INDEX = 0
+            self.N_WORK_UNITS = 128
+            self.MAX_MEMORY_MB = 1024
+
     def _assertExists(self):
         if not os.path.exists(OPENCL_CONFIG_PATH):
             warnings.warn("No OpenCL config file found. Creating a new one.")


### PR DESCRIPTION
- Add CI test matrix covering python 3.9 to 3.13 on 4 different OS (windows, ubuntu, macos-13, macos-15).
Runs with headless PyQt5 support and a properly configured OpenCL device (except for the macos-15 runner).
- Add env var to skip CLConfig setup in CI. 