### PR TITLE
Add env var to disable OpenCL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,8 +100,8 @@ celerybeat-schedule
 # Environments
 .env
 .venv
-env/
-venv/
+env*/
+venv*/
 ENV/
 env.bak/
 venv.bak/

--- a/pytissueoptics/rayscattering/__init__.py
+++ b/pytissueoptics/rayscattering/__init__.py
@@ -15,7 +15,7 @@ from .display.views import (
 )
 from .energyLogging import EnergyLogger
 from .materials import ScatteringMaterial
-from .opencl import CONFIG, hardwareAccelerationIsAvailable
+from .opencl import CONFIG, forceCalculationOnCPU, hardwareAccelerationIsAvailable
 from .photon import Photon
 from .scatteringScene import ScatteringScene
 from .source import DirectionalSource, DivergentSource, IsotropicPointSource, PencilPointSource

--- a/pytissueoptics/rayscattering/__init__.py
+++ b/pytissueoptics/rayscattering/__init__.py
@@ -15,7 +15,7 @@ from .display.views import (
 )
 from .energyLogging import EnergyLogger
 from .materials import ScatteringMaterial
-from .opencl import CONFIG, forceCalculationOnCPU, hardwareAccelerationIsAvailable
+from .opencl import CONFIG, disableOpenCL, hardwareAccelerationIsAvailable
 from .photon import Photon
 from .scatteringScene import ScatteringScene
 from .source import DirectionalSource, DivergentSource, IsotropicPointSource, PencilPointSource
@@ -49,6 +49,7 @@ __all__ = [
     "View2DSliceZ",
     "samples",
     "Stats",
+    "disableOpenCL",
     "hardwareAccelerationIsAvailable",
     "CONFIG",
 ]

--- a/pytissueoptics/rayscattering/opencl/__init__.py
+++ b/pytissueoptics/rayscattering/opencl/__init__.py
@@ -3,7 +3,6 @@ from pytissueoptics.rayscattering.opencl.config.IPPTable import IPPTable
 import os
 
 OPENCL_OK = True
-OPENCL_DISABLED = os.environ.get("PTO_DISABLE_OPENCL", "0") == "1"
 
 if OPENCL_AVAILABLE:
     try:
@@ -39,6 +38,7 @@ def validateOpenCL() -> bool:
 
 
 def hardwareAccelerationIsAvailable() -> bool:
+    OPENCL_DISABLED = os.environ.get("PTO_DISABLE_OPENCL", "0") == "1"
     return OPENCL_AVAILABLE and OPENCL_OK and not OPENCL_DISABLED
 
 

--- a/pytissueoptics/rayscattering/opencl/__init__.py
+++ b/pytissueoptics/rayscattering/opencl/__init__.py
@@ -3,7 +3,7 @@ from pytissueoptics.rayscattering.opencl.config.IPPTable import IPPTable
 import os
 
 OPENCL_OK = True
-PYTISSUE_FORCE_CPU = os.environ.get('PYTISSUE_FORCE_CPU', '0')
+OPENCL_DISABLED = os.environ.get("PTO_DISABLE_OPENCL", "0") == "1"
 
 if OPENCL_AVAILABLE:
     try:
@@ -15,15 +15,17 @@ if OPENCL_AVAILABLE:
 else:
     CONFIG = None
 
-def forceCalculationOnCPU():
-    os.environ["PYTISSUE_FORCE_CPU"] = "1"
-    print("You can define PYTISSUE_FORCE_CPU=1 in your profile to avoid this call.")
+
+def disableOpenCL():
+    os.environ["PTO_DISABLE_OPENCL"] = "1"
+    print("You can define PTO_DISABLE_OPENCL=1 in your profile to avoid this call.")
+
 
 def validateOpenCL() -> bool:
     notAvailableMessage = "Error: Hardware acceleration not available. Falling back to CPU. "
-    
-    if os.environ.get("PYTISSUE_FORCE_CPU", '0') != '0':
-        warnings.warn("User requested not using OpenCL with environment variable 'PYTISSUE_FORCE_CPU'=1.")
+
+    if os.environ.get("PTO_DISABLE_OPENCL", "0") == "1":
+        warnings.warn("User requested not to use OpenCL with environment variable 'PTO_DISABLE_OPENCL'=1.")
         return False
     if not OPENCL_AVAILABLE:
         warnings.warn(notAvailableMessage + "Please install pyopencl.")
@@ -37,7 +39,7 @@ def validateOpenCL() -> bool:
 
 
 def hardwareAccelerationIsAvailable() -> bool:
-    return OPENCL_AVAILABLE and OPENCL_OK and not PYTISSUE_FORCE_CPU
+    return OPENCL_AVAILABLE and OPENCL_OK and not OPENCL_DISABLED
 
 
 __all__ = ["IPPTable", "WEIGHT_THRESHOLD"]

--- a/pytissueoptics/rayscattering/opencl/__init__.py
+++ b/pytissueoptics/rayscattering/opencl/__init__.py
@@ -1,7 +1,9 @@
 from pytissueoptics.rayscattering.opencl.config.CLConfig import OPENCL_AVAILABLE, WEIGHT_THRESHOLD, CLConfig, warnings
 from pytissueoptics.rayscattering.opencl.config.IPPTable import IPPTable
+import os
 
 OPENCL_OK = True
+PYTISSUE_FORCE_CPU = os.environ.get('PYTISSUE_FORCE_CPU', '0')
 
 if OPENCL_AVAILABLE:
     try:
@@ -13,9 +15,16 @@ if OPENCL_AVAILABLE:
 else:
     CONFIG = None
 
+def forceCalculationOnCPU():
+    os.environ["PYTISSUE_FORCE_CPU"] = "1"
+    print("You can define PYTISSUE_FORCE_CPU=1 in your profile to avoid this call.")
 
 def validateOpenCL() -> bool:
     notAvailableMessage = "Error: Hardware acceleration not available. Falling back to CPU. "
+    
+    if os.environ.get("PYTISSUE_FORCE_CPU", '0') != '0':
+        warnings.warn("User requested not using OpenCL with environment variable 'PYTISSUE_FORCE_CPU'=1.")
+        return False
     if not OPENCL_AVAILABLE:
         warnings.warn(notAvailableMessage + "Please install pyopencl.")
         return False
@@ -28,7 +37,7 @@ def validateOpenCL() -> bool:
 
 
 def hardwareAccelerationIsAvailable() -> bool:
-    return OPENCL_AVAILABLE and OPENCL_OK
+    return OPENCL_AVAILABLE and OPENCL_OK and not PYTISSUE_FORCE_CPU
 
 
 __all__ = ["IPPTable", "WEIGHT_THRESHOLD"]


### PR DESCRIPTION
Cherry-picked from https://github.com/DCC-Lab/PyTissueOptics/pull/113 and renamed `PTO_DISABLE_OPENCL` to fit existing naming pattern and take into account that OpenCL is architecture agnostic.