### PR TITLE
Add raw data export

### DIFF
--- a/pytissueoptics/scene/solids/cuboid.py
+++ b/pytissueoptics/scene/solids/cuboid.py
@@ -151,3 +151,6 @@ class Cuboid(Solid):
         for surfaceLabel in layerSurfaceLabels:
             polygons.extend(self._surfaces.getPolygons(surfaceLabel))
         return polygons
+
+    def _geometryParams(self) -> dict:
+        return {"shape": self.shape}

--- a/pytissueoptics/scene/solids/cylinder.py
+++ b/pytissueoptics/scene/solids/cylinder.py
@@ -164,3 +164,12 @@ class Cylinder(Solid):
         materialHash = hash(self._material) if self._material else 0
         propertyHash = hash((self._radius, self._length, self._frontCenter, self._backCenter))
         return hash((materialHash, propertyHash))
+
+    def _geometryParams(self) -> dict:
+        return {
+            "radius": self._radius,
+            "length": self._length,
+            "u": self._u,
+            "v": self._v,
+            "s": self._s,
+        }

--- a/pytissueoptics/scene/solids/ellipsoid.py
+++ b/pytissueoptics/scene/solids/ellipsoid.py
@@ -212,3 +212,11 @@ class Ellipsoid(Solid):
 
     def _getMinimumRadiusTowards(self, vertex) -> float:
         return (1 - self._getRadiusError()) * self._radiusTowards(vertex)
+
+    def _geometryParams(self) -> dict:
+        return {
+            "radius_a": self._a,
+            "radius_b": self._b,
+            "radius_c": self._c,
+            "order": self._order,
+        }

--- a/pytissueoptics/scene/solids/lens.py
+++ b/pytissueoptics/scene/solids/lens.py
@@ -50,6 +50,7 @@ class ThickLens(Cylinder):
         self._diameter = diameter
         self._frontRadius = frontRadius
         self._backRadius = backRadius
+        self._thickness = thickness
 
         length = self._computeEdgeThickness(thickness)
         super().__init__(
@@ -155,6 +156,18 @@ class ThickLens(Cylinder):
             return super(Cylinder, self).smooth(surfaceLabel, reset)
         for surfaceLabel in ["front", "back"]:
             self.smooth(surfaceLabel, reset=False)
+
+    def _geometryParams(self) -> dict:
+        return {
+            "diameter": self._diameter,
+            "frontRadius": self._frontRadius,
+            "backRadius": self._backRadius,
+            "thickness": self._thickness,
+            "length": self._length,
+            "u": self._u,
+            "v": self._v,
+            "s": self._s,
+        }
 
 
 class SymmetricLens(ThickLens):

--- a/pytissueoptics/scene/solids/solid.py
+++ b/pytissueoptics/scene/solids/solid.py
@@ -1,6 +1,6 @@
 import warnings
 from functools import partial
-from typing import Callable, Dict, List
+from typing import Any, Callable, Dict, List
 
 import numpy as np
 
@@ -332,3 +332,20 @@ class Solid:
         verticesHash = hash(tuple(sorted([hash(v) for v in self._vertices])))
         materialHash = hash(self._material) if self._material else 0
         return hash((verticesHash, materialHash))
+
+    def geometryExport(self) -> dict[str, Any]:
+        """Used to describe geometry during data export."""
+        params = {
+            **self._geometryParams(),
+            "position": self.position.array,
+            "bbox": self.getBoundingBox().xyzLimits,
+        }
+        if self._orientation != INITIAL_SOLID_ORIENTATION:
+            params["orientation"] = self._orientation.array
+        if self._rotation:
+            params["rotation"] = [self._rotation.xTheta, self._rotation.yTheta, self._rotation.zTheta]
+        return params
+
+    def _geometryParams(self) -> dict:
+        """To be implemented by Solid subclasses to detail other geometry parameters."""
+        return {}

--- a/pytissueoptics/scene/solids/sphere.py
+++ b/pytissueoptics/scene/solids/sphere.py
@@ -59,3 +59,9 @@ class Sphere(Ellipsoid):
 
     def _radiusTowards(self, vertex) -> float:
         return self.radius
+
+    def _geometryParams(self) -> dict:
+        return {
+            "radius": self._radius,
+            "order": self._order,
+        }


### PR DESCRIPTION
- Added `EnergyLogger.export(exportPath)` which exports all raw data points to `exportPath.csv` as `energy, x, y, z, solid_index, surface_index`, and all related scene metadata (including material and geometrical properties) to `exportPath.json`. 