### PR TITLE
Fix pipeline: deprecated runner and numpy typing

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-13, macos-latest, windows-latest]
+        os: [ubuntu-latest, macos-15-intel, macos-latest, windows-latest]
         python-version: ["3.9", "3.13"]
 
         include:

--- a/pytissueoptics/rayscattering/tests/opencl/src/testCLFresnel.py
+++ b/pytissueoptics/rayscattering/tests/opencl/src/testCLFresnel.py
@@ -169,7 +169,7 @@ class TestCLFresnel(unittest.TestCase):
             N=N,
             arguments=[np.float32(self.n1), np.float32(self.n2), np.float32(thetaIn), coefficientBuffer],
         )
-        return float(self.program.getData(coefficientBuffer)[0])
+        return float(self.program.getData(coefficientBuffer)[0][0])
 
     def _getFresnelResult(self, fresnelBuffer) -> FresnelResult:
         fresnelIntersection = self.program.getData(fresnelBuffer)[0]

--- a/pytissueoptics/rayscattering/tests/testScatteringScene.py
+++ b/pytissueoptics/rayscattering/tests/testScatteringScene.py
@@ -1,6 +1,5 @@
 import math
 import unittest
-from unittest.mock import patch
 
 from mockito import mock, verify, when
 
@@ -9,12 +8,6 @@ from pytissueoptics.rayscattering.materials import ScatteringMaterial
 from pytissueoptics.rayscattering.scatteringScene import ScatteringScene
 from pytissueoptics.scene.solids import Cuboid
 from pytissueoptics.scene.viewer import Abstract3DViewer
-
-
-def patchMayaviShow(func):
-    for module in ["show", "gcf", "figure", "clf", "triangular_mesh"]:
-        func = patch("mayavi.mlab." + module)(func)
-    return func
 
 
 class TestScatteringScene(unittest.TestCase):
@@ -36,13 +29,6 @@ class TestScatteringScene(unittest.TestCase):
         scene.addToViewer(viewer)
 
         verify(viewer).add(*scene.solids, ...)
-
-    @patchMayaviShow
-    def testWhenShow_shouldShowInside3DViewer(self, mockShow, *args):
-        scene = ScatteringScene([Cuboid(1, 1, 1, material=ScatteringMaterial())])
-        scene.show()
-
-        mockShow.assert_called_once()
 
     def testShouldHaveIPPEstimationUsingMeanAlbedoInInfiniteMedium(self):
         material1 = ScatteringMaterial(mu_s=1, mu_a=0.7, g=0.9)


### PR DESCRIPTION
- Replace deprecated gh runner macos-13 with macos-15-intel (which still includes opencl support).
- Support new numpy version (drop implicit cast of size-1 N-dim array to 0-dim)